### PR TITLE
NewProject command automatically looks for and adds Strongback user library

### DIFF
--- a/strongback-tools/.classpath
+++ b/strongback-tools/.classpath
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="src" output="build/test-classes" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="/libs/test/fest-assert-1.4.jar" sourcepath="/libs/test/fest-assert-1.4-sources.jar"/>
 	<classpathentry kind="lib" path="/libs/test/fest-util-1.1.6.jar" sourcepath="/libs/test/fest-util-1.1.6-sources.jar"/>
 	<classpathentry kind="lib" path="/libs/test/hamcrest-core-1.3.jar" sourcepath="/libs/test/hamcrest-core-1.3-sources.jar"/>
-	<classpathentry kind="output" path="build/test-classes"/>
+	<classpathentry kind="output" path="build/classes"/>
 </classpath>

--- a/strongback-tools/test/org/strongback/tools/newproject/NewProjectTest.java
+++ b/strongback-tools/test/org/strongback/tools/newproject/NewProjectTest.java
@@ -1,0 +1,64 @@
+/*
+ * Strongback
+ * Copyright 2015, Strongback and individual contributors by the @authors tag.
+ * See the COPYRIGHT.txt in the distribution for a full listing of individual
+ * contributors.
+ *
+ * Licensed under the MIT License; you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.strongback.tools.newproject;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+/**
+ * @author Randall Hauch
+ *
+ */
+public class NewProjectTest {
+
+    @Test
+    public void shouldEscapeUserlibTemplateCorrectly() throws IOException {
+        boolean print = false;
+        File template = new File("../templates/Strongback.userlibraries.template");
+        if (!template.exists()) {
+            template = new File("templates/Strongback.userlibraries.template");
+        }
+        assertThat(template.exists()).isTrue();
+
+        List<String> lines = Files.readAllLines(template.toPath(), StandardCharsets.UTF_8);
+        List<String> updated = lines.stream().collect(Collectors.toList());
+        if (print) updated.forEach(System.out::println);
+        String content = NewProject.combineAndEscape(updated,"/Users/jsmith/strongback");
+        if (print) System.out.println(content);
+        assertThat(content.indexOf("STRONGBACK")).isEqualTo(-1);
+        // assertThat(content.indexOf(" ")).isEqualTo(-1);
+
+        Properties props = new Properties();
+        props.setProperty("template", content);
+        ByteArrayOutputStream ostream = new ByteArrayOutputStream();
+        props.store(ostream, "");
+        String propFileContents = new String(ostream.toByteArray());
+        assertThat(propFileContents.contains(">\\n\\t\\t<attributes")).isTrue();
+        assertThat(propFileContents.contains("\"file\\:/Users/jsmith")).isTrue();
+    }
+
+}

--- a/templates/Strongback.userlibraries.import.template
+++ b/templates/Strongback.userlibraries.import.template
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<eclipse-userlibraries version="2">
+    <library name="Strongback" systemlibrary="false">
+        <archive javadoc="file:STRONGBACKHOME/java/javadoc/" path="STRONGBACKHOME/java/lib/strongback.jar" source="STRONGBACKHOME/java/lib/strongback-sources.jar"/>
+        <archive javadoc="file:STRONGBACKHOME/java/javadoc/" path="STRONGBACKHOME/java/lib-tests/strongback-testing.jar" source="STRONGBACKHOME/java/lib-tests/strongback-testing-sources.jar"/>
+        <archive javadoc="file:STRONGBACKHOME/java/javadoc/" path="STRONGBACKHOME/java/lib-tests/fest-assert-1.4.jar" source="STRONGBACKHOME/java/lib-tests/fest-assert-1.4-sources.jar"/>
+        <archive javadoc="file:STRONGBACKHOME/java/javadoc/" path="STRONGBACKHOME/java/lib-tests/fest-util-1.1.6.jar" source="STRONGBACKHOME/java/lib-tests/fest-util-1.1.6-sources.jar"/>
+        <archive javadoc="file:STRONGBACKHOME/java/javadoc/" path="STRONGBACKHOME/java/lib-tests/hamcrest-core-1.3.jar" source="STRONGBACKHOME/java/lib-tests/hamcrest-core-1.3-sources.jar"/>
+        <archive javadoc="file:STRONGBACKHOME/java/javadoc/" path="STRONGBACKHOME/java/lib-tests/junit-4.11.jar" source="STRONGBACKHOME/java/lib-tests/junit-4.11-sources.jar"/>
+        <archive javadoc="file:STRONGBACKHOME/java/javadoc/" path="STRONGBACKHOME/java/lib-tests/metrics-core-3.1.0.jar" source="STRONGBACKHOME/java/lib-tests/metrics-core-3.1.0-sources.jar"/>
+    </library>
+</eclipse-userlibraries>

--- a/templates/Strongback.userlibraries.template
+++ b/templates/Strongback.userlibraries.template
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<userlibrary systemlibrary="false" version="2">
+    <archive path="STRONGBACKHOME/java/lib/strongback.jar" sourceattachment="STRONGBACKHOME/java/lib/strongback-sources.jar">
+        <attributes>
+            <attribute name="javadoc_location" value="file:STRONGBACKHOME/java/javadoc/"/>
+        </attributes>
+    </archive>
+    <archive path="STRONGBACKHOME/java/lib-tests/strongback-testing.jar" sourceattachment="STRONGBACKHOME/java/lib-tests/strongback-testing-sources.jar">
+        <attributes>
+            <attribute name="javadoc_location" value="file:STRONGBACKHOME/java/javadoc/"/>
+        </attributes>
+    </archive>
+    <archive path="STRONGBACKHOME/java/lib-tests/fest-assert-1.4.jar" sourceattachment="STRONGBACKHOME/java/lib-tests/fest-assert-1.4-sources.jar">
+        <attributes>
+            <attribute name="javadoc_location" value="file:STRONGBACKHOME/java/javadoc/"/>
+        </attributes>
+    </archive>
+    <archive path="STRONGBACKHOME/java/lib-tests/fest-util-1.1.6.jar" sourceattachment="STRONGBACKHOME/java/lib-tests/fest-util-1.1.6-sources.jar">
+        <attributes>
+            <attribute name="javadoc_location" value="file:STRONGBACKHOME/java/javadoc/"/>
+        </attributes>
+    </archive>
+    <archive path="STRONGBACKHOME/java/lib-tests/hamcrest-core-1.3.jar" sourceattachment="STRONGBACKHOME/java/lib-tests/hamcrest-core-1.3-sources.jar">
+        <attributes>
+            <attribute name="javadoc_location" value="file:STRONGBACKHOME/java/javadoc/"/>
+        </attributes>
+    </archive>
+    <archive path="STRONGBACKHOME/java/lib-tests/junit-4.11.jar" sourceattachment="STRONGBACKHOME/java/lib-tests/junit-4.11-sources.jar">
+        <attributes>
+            <attribute name="javadoc_location" value="file:STRONGBACKHOME/java/javadoc/"/>
+        </attributes>
+    </archive>
+    <archive path="STRONGBACKHOME/java/lib-tests/metrics-core-3.1.0.jar" sourceattachment="STRONGBACKHOME/java/lib-tests/metrics-core-3.1.0-sources.jar">
+        <attributes>
+            <attribute name="javadoc_location" value="file:STRONGBACKHOME/java/javadoc/"/>
+        </attributes>
+    </archive>
+</userlibrary>

--- a/templates/classpath.template
+++ b/templates/classpath.template
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
         <classpathentry kind="src" path="src"/>
-        <classpathentry kind="src" path="testsrc"/>
-        
+        <classpathentry kind="src" output="build/test-classes" path="testsrc"/>
         <classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
         <classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
-        
         <classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Strongback"/>
         <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-        
-        <classpathentry kind="output" path="bin"/>
+        <classpathentry kind="output" path="build/classes"/>
 </classpath>


### PR DESCRIPTION
The command looks for the `.metadata` directory as a sibling to the new project directory, and if it finds it it looks for the `Strongback` user library. If the user library if it is not there, it is automatically added. 

If the `.metadata` directory could not be found, then the output messages now tell the user to import the Strongback user library (which is now generated into the `strongback/java/eclipse` folder when `new-project` is first run).
