### PR TITLE
Automatically install WPILib locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,8 @@ deploy/
 target/
 *.class
 
+# The wpilib directory should never be committed
+libs/wpilib
+downloads/
+
 .DS_Store/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@ Strongback is a new open source software library that makes your robot code ligh
 * **Logging** - Simple extendable framework to log messages at different levels.
 * **Uses WPILib** - Uses the WPILib classes underneath for safety and consistency.
 
+# Using Strongback
+
 Check out our new [Using Strongback](https://www.gitbook.com/book/strongback/using-strongback/) online book. It's chocked full of descriptions, details, and example code. The book's [Getting Started](https://strongback.gitbooks.io/using-strongback/content/getting_started.html) section shows you how to download, install, and use the [latest release](https://github.com/strongback/strongback-java/releases). Or, look at [this presentation](http://slides.com/strongback/using-strongback/#/) for an overview of the major features.
 
 We're just getting started, so stay tuned. See [our wiki](https://github.com/strongback/strongback-java/wiki) for more details, including how you can help out!
+
+# Building locally
+
+If you want to build Strongback locally, you will need to have installed JDK 1.8, Eclipse Mars (version 4.5.0 or later), Ant 1.9.2 or later, and Git 2.2.1 or later. Then, use Git to clone this repository (or your GitHub fork). Before importing into Eclipse, build the code and run the unit tests using Ant:
+
+    $ ant test
+
+This will download the appropriate version of WPILib and install it into the `libs` directory, and then compile all the code and run the unit tests. Once this works, you know your environment is set up correctly, and you can proceed to import the projects into your Eclipse workspace and view or make changes to the library and/or tests using Eclipse. At any time, you can run Ant to compile, test, or create distribution files.
+
+If you have any problems getting this far, please check our [developers discussion forum](https://groups.google.com/forum/#!forum/strongback-dev) to see if others are having similar problems. If you see no relevant discussion, post a question with the details about your platform, the versions of the tools, what you are trying to do, and what result you are getting. 
+
+# Releasing
+
+To release a new version of Strongback:
+
+1. Change the `strongback.properties` file to reference the correct version number, and commit that to the repository. 
+1. Build the distribution by running `ant clean dist` and verifying it completed correctly.
+1. Go to the [Strongback releases page](https://github.com/strongback/strongback-java/releases) and draft a new release, filling in the correct release candidate version number as the tag (e.g., `v1.0.0.RC1` for "release candidate 1") and giving an appropriate release title (e.g., `1.0.0 Release Candidate 1`) and description, and uploading the ZIP and compressed TAR file in the `build` directory. Then check "This is a pre-release" and press "Publish Release".
+1. Notify the developer forum so that other community members can test the release candidate by downloading and unpacking the pre-release distribution into their local home directory, using it in one or more robot codebases, and verifying the robots behave as expected. Each community member that tests it locally should respond to your forum post with their results.
+1. If the pre-release distribution has problems that need to be fixed, they should be reported, fixed, and merged into the correct branch, and then go to Step 3 using a new pre-release tag (e.g., `v1.0.0.RC2`) and title (e.g., `1.0.0 Release Candidate 1`).
+1. When enough community members have verified the pre-release distribution is acceptable, go to the [Strongback releases page](https://github.com/strongback/strongback-java/releases) and create a new release with the same tag as the pre-release, but with the appropriate release title (e.g., `1.0.0`) and description. Do not check "This is a pre-release" and press "Publish Release".

--- a/build-common.xml
+++ b/build-common.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <project name="build-common" default="test">
 
-    <property name="strongback.dir" value=".."/>
+    <property name="strongback.dir" location=".."/>
     <property file="${strongback.dir}/build.properties"/>
+    <property name="wpilib.dir" value="${strongback.dir}/libs/wpilib"/>
 
-    <property name="wpilib.dir" value="${user.home}/wpilib"/>
     <property name="java.compile.arg" value=""/>
     <property name="java.source.version" value="1.8"/>
     <property name="java.target.version" value="1.8"/>
@@ -57,6 +57,7 @@
     </target>
 
     <target name="compile" description="Compile the code">
+        <echo>Compiling against WPILib ${wpilib.version} installed at ${wpilib.dir}</echo>
         <mkdir dir="${project.output.dir}"/>
         <javac srcdir="${project.source.dir}" 
                destdir="${project.output.dir}" 
@@ -75,6 +76,7 @@
     </target>
 
     <target name="compile-tests" depends="compile, if-tests" if="tests-exists" description="Compile the unit tests">
+        <echo>Compiling against WPILib ${wpilib.version} installed at ${wpilib.dir}</echo>
         <mkdir dir="${project.test.output.dir}"/>
         <javac srcdir="${project.test.source.dir}" 
                destdir="${project.test.output.dir}" 
@@ -97,6 +99,7 @@
 
     <!-- Run the JUnit Tests that are in the 'test' directory of this project -->
     <target name="test" depends="compile-tests, if-tests" if="tests-exists" description="Run the unit tests">
+        <echo>Testing with WPILib ${wpilib.version} installed at ${wpilib.dir}</echo>
         <!-- Creates the directories used in the tests -->
         <mkdir dir="${project.test.output.dir}" />
         <mkdir dir="${project.test.report.dir}" />

--- a/build.properties
+++ b/build.properties
@@ -1,2 +1,8 @@
 strongback.version=1.0.1
-wpilib.dir=${user.home}/wpilib
+#
+# The build will download a specific version of the WPILib given by the following URL
+# and install it into the 'libs/wpilib' folder. To use a different version of WPILib,
+# replace the value with the URL of the WPILib Eclipse Update Site
+#
+wpilib.updatesite.url=http://first.wpi.edu/FRC/roborio/release/eclipse
+

--- a/build.xml
+++ b/build.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<project name="strongback" default="dist">
+<project name="strongback" default="dist" xmlns:antcontrib="antlib:net.sf.antcontrib">
+    <!-- Add Ant-Contrib -->
+    <taskdef uri="antlib:net.sf.antcontrib"
+             resource="net/sf/antcontrib/antlib.xml"
+             classpath="libs/build/ant-contrib-1.0b3.jar"/>
+
     <import file="dependencies.xml"/>
     <tstamp>
         <format property="current.year" pattern="yyyy" locale="en"/>
         <format property="current.date" pattern="yyyy-MM-dd" locale="en"/>
     </tstamp>
     <property file="build.properties"/>
+    <property name="wpilib.dir" value="libs/wpilib"/>
     <property name="wpi.libs.dir" value="${wpilib.dir}/java/current/lib"/>
+    <property file="${wpilib.dir}/wpilib.properties"/>
     <property name="build.dir" value="build"/>
 
     <target name="help">
@@ -16,11 +23,18 @@
         <echo>   compile       Compiles the source code in all projects</echo>
         <echo>   test          Compiles and runs the tests in all projects</echo>
         <echo>   jar           Compiles, runs the tests, and builds JAR files for all projects</echo>
-        <echo>   dist          Creates the distribution archive</echo>
+        <echo>   javadoc       Builds the JavaDoc</echo>
+        <echo>   dist          Creates the distribution ZIP and TAR archives in the `build` directory</echo>
         <echo></echo>
         <echo>Some of these targets depend on other targets. For example, running 'ant test' will</echo>
         <echo>automatically include the 'compile' target, so it is equivalent to running 'ant compile test'.</echo>
         <echo>Likewise, 'jar' automatically runs 'test', and 'dist' automatically runs 'clean' and 'jar'.</echo>
+        <echo></echo>
+        <echo>There are a few other targets that are automatically run when the above targets are used,</echo>
+        <echo>but which you may want to run manually:</echo>
+        <echo></echo>
+        <echo>   dep           Install the dependencies required to compile, run tests, and create the distribution.</echo>
+        <echo>   remove-dep    Remove the dependencies installed by `dep`</echo>
         <echo></echo>
     </target>
 
@@ -31,19 +45,19 @@
         </antcall>
     </target>
 
-    <target name="compile" description="Compiles source code">
+    <target name="compile" depends="dep" description="Compiles source code">
         <antcall target="strongback.all">
             <param name="dependency.target" value="compile"/>
         </antcall>
     </target>
 
-    <target name="test" description="Run the tests">
+    <target name="test" depends="dep" description="Run the tests">
         <antcall target="strongback.all">
             <param name="dependency.target" value="test"/>
         </antcall>
     </target>
 
-    <target name="jar" description="Creates the JARs">
+    <target name="jar" depends="dep" description="Creates the JARs">
         <antcall target="strongback.all">
             <param name="dependency.target" value="jar"/>
         </antcall>
@@ -85,6 +99,7 @@
 
     <target name="dist" depends="clean, jar, javadoc" description="Creates the distribution">
         <echo>Building Strongback distribution version ${strongback.version}</echo>
+        <echo>for the WPILib version ${wpilib.version} installed at ${wpilib.dir}</echo>
         <mkdir dir="build"/>
 
         <!-- Update the strongback.properties file -->
@@ -120,4 +135,82 @@
         <delete file="${build.dir}/strongback-${strongback.version}.tar" />
 
     </target>
+
+    <!-- Remove and clean dependencies -->
+    <target name="remove-dep" depends="clean-downloads" description="Removes the locally-installed dependencies">
+        <!-- !!!! Always remove the *local* installation; never the one in ${wpilib.dir} !!!! -->
+        <delete dir="libs/wpilib" />
+    </target>
+
+    <!-- Remove and clean dependencies -->
+    <target name="clean-downloads" description="Deletes the temporary downloads folder">
+        <delete dir="downloads" />
+    </target>
+
+    <!-- Install Dependencies -->
+    <target name="dep" depends="download-wpilib,clean-downloads" description="Downloads and installs the dependencies required for the build">
+    </target>
+
+    <!-- Check if the WPI directory exists -->
+    <target name="check-for-wpilib">
+        <condition property="wpilib-missing">
+            <not>
+                <available file="${wpilib.dir}" type="dir"/>
+            </not>
+        </condition>
+    </target>
+
+    <!-- Install the WPI directory -->
+    <target name="download-wpilib" depends="check-for-wpilib" if="wpilib-missing" >
+        <echo>Downloading the WPILib library and installing into '${wpilib.dir}'.</echo>
+        <mkdir dir="downloads"/>
+        <!-- Download the 'site.xml' file that contains the URL to the feature we want, and get that URL -->
+        <get src="${wpilib.updatesite.url}/site.xml" dest="downloads/site.xml"/>
+        <xmlproperty file="downloads/site.xml" collapseAttributes="true" semanticAttributes="true" keepRoot="true"/>
+        <antcontrib:for list="${site.feature.url}" param="url">
+            <sequential>
+                <antcontrib:if>
+                    <contains string="@{url}" substring="java.feature"/>
+                    <then>
+                        <property name="javaFeatureUrl" value="@{url}"/>
+                    </then>
+                </antcontrib:if>
+            </sequential>
+        </antcontrib:for>
+        <antcontrib:propertyregex property="wpilib.version" input="${javaFeatureUrl}" regexp="_([\d.]*).jar" select="\1" casesensitive="false" />
+        <!-- The feature URL can be converted to the plugin URL -->
+        <loadresource property="javaPluginUrl">
+          <propertyresource name="javaFeatureUrl"/>
+          <filterchain>
+            <tokenfilter>
+              <filetokenizer/>
+              <replacestring from="features" to="plugins"/>
+            </tokenfilter>
+            <tokenfilter>
+              <filetokenizer/>
+              <replacestring from="java.feature" to="java"/>
+            </tokenfilter>
+          </filterchain>
+        </loadresource>
+        <!-- Get the plugin JAR file, and extract it's 'java.zip' file -->
+        <get src="${wpilib.updatesite.url}/${javaPluginUrl}" dest="downloads/wpi-java-plugin.jar"/>
+        <unzip src="downloads/wpi-java-plugin.jar" dest="downloads">
+            <patternset>
+                <include name="**/java.zip"/>
+            </patternset>
+        </unzip>
+        <!-- Extract the 'java.zip' file into a new `wpilib` directory -->
+        <mkdir dir="${wpilib.dir}/java/current"/>
+        <unzip src="downloads/resources/java.zip" dest="${wpilib.dir}/java/current">
+            <patternset>
+                <include name="**/*"/>
+            </patternset>
+        </unzip>
+        <!-- Write out a property file in the directory -->
+        <propertyfile file="${wpilib.dir}/wpilib.properties" comment="Downloaded and installed by Strongback build system">
+            <entry  key="version" value="current"/>
+            <entry  key="wpilib.version" value="${wpilib.version}"/>
+        </propertyfile>
+    </target>
+
 </project>

--- a/strongback-examples/.classpath
+++ b/strongback-examples/.classpath
@@ -2,12 +2,12 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
+	<classpathentry kind="lib" path="/libs/wpilib/java/current/lib/WPILib.jar" sourcepath="/libs/wpilib/java/current/lib/WPILib-sources.jar"/>
+	<classpathentry kind="lib" path="/libs/wpilib/java/current/lib/NetworkTables.jar" sourcepath="/libs/wpilib/java/current/lib/NetworkTables-sources.jar"/>
 	<classpathentry kind="lib" path="/libs/test/fest-assert-1.4.jar" sourcepath="/libs/test/fest-assert-1.4-sources.jar"/>
 	<classpathentry kind="lib" path="/libs/test/fest-util-1.1.6.jar" sourcepath="/libs/test/fest-util-1.1.6-sources.jar"/>
 	<classpathentry kind="lib" path="/libs/test/junit-4.11.jar" sourcepath="/libs/test/junit-4.11-sources.jar"/>
 	<classpathentry kind="lib" path="/libs/test/hamcrest-core-1.3.jar" sourcepath="/libs/test/hamcrest-core-1.3-sources.jar"/>
-	<classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/strongback"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>

--- a/strongback-testing/.classpath
+++ b/strongback-testing/.classpath
@@ -2,10 +2,10 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
-	<classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
 	<classpathentry kind="lib" path="/libs/test/junit-4.11.jar" sourcepath="/libs/test/junit-4.11-sources.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/strongback"/>
 	<classpathentry kind="lib" path="/libs/test/metrics-core-3.1.0.jar" sourcepath="/libs/test/metrics-core-3.1.0-sources.jar"/>
+	<classpathentry kind="lib" path="/libs/wpilib/java/current/lib/WPILib.jar" sourcepath="/libs/wpilib/java/current/lib/WPILib-sources.jar"/>
+	<classpathentry kind="lib" path="/libs/wpilib/java/current/lib/NetworkTables.jar" sourcepath="/libs/wpilib/java/current/lib/NetworkTables-sources.jar"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>

--- a/strongback-tests/.classpath
+++ b/strongback-tests/.classpath
@@ -2,13 +2,13 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
-	<classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
 	<classpathentry kind="lib" path="/libs/test/fest-assert-1.4.jar" sourcepath="/libs/test/fest-assert-1.4-sources.jar"/>
 	<classpathentry kind="lib" path="/libs/test/fest-util-1.1.6.jar" sourcepath="/libs/test/fest-util-1.1.6-sources.jar"/>
 	<classpathentry kind="lib" path="/libs/test/junit-4.11.jar" sourcepath="/libs/test/junit-4.11-sources.jar"/>
 	<classpathentry kind="lib" path="/libs/test/hamcrest-core-1.3.jar" sourcepath="/libs/test/hamcrest-core-1.3-sources.jar"/>
 	<classpathentry kind="lib" path="/libs/test/metrics-core-3.1.0.jar" sourcepath="/libs/test/metrics-core-3.1.0-sources.jar"/>
+	<classpathentry kind="lib" path="/libs/wpilib/java/current/lib/WPILib.jar" sourcepath="/libs/wpilib/java/current/lib/WPILib-sources.jar"/>
+	<classpathentry kind="lib" path="/libs/wpilib/java/current/lib/NetworkTables.jar" sourcepath="/libs/wpilib/java/current/lib/NetworkTables-sources.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/strongback"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/strongback-testing"/>
 	<classpathentry kind="output" path="build/classes"/>

--- a/strongback/.classpath
+++ b/strongback/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="var" path="wpilib" sourcepath="wpilib.sources"/>
-	<classpathentry kind="var" path="networktables" sourcepath="networktables.sources"/>
+	<classpathentry kind="lib" path="/libs/wpilib/java/current/lib/WPILib.jar" sourcepath="/libs/wpilib/java/current/lib/WPILib-sources.jar"/>
+	<classpathentry kind="lib" path="/libs/wpilib/java/current/lib/NetworkTables.jar" sourcepath="/libs/wpilib/java/current/lib/NetworkTables-sources.jar"/>
 	<classpathentry kind="output" path="build/classes"/>
 </classpath>


### PR DESCRIPTION
This commit changes the build to use a WPILib distribution inside the `libs` folder. If the installation is not there, the Ant build will automatically download it via the standard WPILib Eclipse Update Site, and extract the Java-related artifacts into the `libs/wpilib` directory. The Eclipse projects were also changed to use this local installation.

A local installation of WPILib will greatly improve consistency between different developers, and help us to maintain Strongback versions/branches that use different versions of WPILib.

Closes #20 
