### PR TITLE
Added a TalonController to work with hardware-based PID control on Talon SRX devices

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-strongback.version=1.1.0-Alpha2-SNAPSHOT
+strongback.version=1.1.0-Alpha3-SNAPSHOT
 #
 # The build will download a specific version of the WPILib given by the following URL
 # and install it into the 'libs/wpilib' folder. To use a different version of WPILib,

--- a/strongback-testing/src/org/strongback/mock/Mock.java
+++ b/strongback-testing/src/org/strongback/mock/Mock.java
@@ -17,6 +17,9 @@
 package org.strongback.mock;
 
 import org.strongback.components.Fuse;
+import org.strongback.components.TalonSRX;
+import org.strongback.control.Controller;
+import org.strongback.control.PIDController;
 
 /**
  * Factory for mock components.
@@ -230,7 +233,7 @@ public class Mock {
     }
 
     /**
-     * Create a stopped mock Talon SRX motor.
+     * Create a stopped mock {@link TalonSRX} motor.
      *
      * @return the mock TalonSRX motor; never null
      */
@@ -239,12 +242,28 @@ public class Mock {
     }
 
     /**
-     * Create a running mock Talon SRX motor.
+     * Create a running mock {@link TalonSRX} motor.
      *
      * @param speed the initial speed
      * @return the mock TalonSRX motor; never null
      */
     public static MockTalonSRX runningTalonSRX(double speed) {
         return new MockTalonSRX(speed);
+    }
+
+    /**
+     * Create a mock {@link Controller}.
+     * @return the mock controller; never null
+     */
+    public static MockController controller() {
+        return new MockController();
+    }
+
+    /**
+     * Create a mock {@link PIDController}.
+     * @return the mock controller; never null
+     */
+    public static MockPIDController pidController() {
+        return new MockPIDController();
     }
 }

--- a/strongback-testing/src/org/strongback/mock/Mock.java
+++ b/strongback-testing/src/org/strongback/mock/Mock.java
@@ -16,6 +16,8 @@
 
 package org.strongback.mock;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.strongback.components.Fuse;
 import org.strongback.components.TalonSRX;
 import org.strongback.control.Controller;
@@ -27,6 +29,8 @@ import org.strongback.control.PIDController;
  * @author Randall Hauch
  */
 public class Mock {
+
+    private static final AtomicLong CAN_DEVICE_ID_GENERATOR = new AtomicLong();
 
     /**
      * Create a mock power panel.
@@ -235,10 +239,31 @@ public class Mock {
     /**
      * Create a stopped mock {@link TalonSRX} motor.
      *
+     * @param deviceId the CAN device ID
+     * @return the mock TalonSRX motor; never null
+     */
+    public static MockTalonSRX stoppedTalonSRX(int deviceId) {
+        return runningTalonSRX(deviceId, 0.0);
+    }
+
+    /**
+     * Create a running mock {@link TalonSRX} motor.
+     *
+     * @param deviceId the CAN device ID
+     * @param speed the initial speed
+     * @return the mock TalonSRX motor; never null
+     */
+    public static MockTalonSRX runningTalonSRX(int deviceId, double speed) {
+        return new MockTalonSRX(deviceId, speed);
+    }
+
+    /**
+     * Create a stopped mock {@link TalonSRX} motor.
+     *
      * @return the mock TalonSRX motor; never null
      */
     public static MockTalonSRX stoppedTalonSRX() {
-        return new MockTalonSRX(0.0);
+        return stoppedTalonSRX(nextDeviceId());
     }
 
     /**
@@ -248,11 +273,16 @@ public class Mock {
      * @return the mock TalonSRX motor; never null
      */
     public static MockTalonSRX runningTalonSRX(double speed) {
-        return new MockTalonSRX(speed);
+        return runningTalonSRX(nextDeviceId(), speed);
+    }
+
+    protected static int nextDeviceId() {
+        return (int)CAN_DEVICE_ID_GENERATOR.getAndIncrement();
     }
 
     /**
      * Create a mock {@link Controller}.
+     *
      * @return the mock controller; never null
      */
     public static MockController controller() {
@@ -261,6 +291,7 @@ public class Mock {
 
     /**
      * Create a mock {@link PIDController}.
+     *
      * @return the mock controller; never null
      */
     public static MockPIDController pidController() {

--- a/strongback-testing/src/org/strongback/mock/MockController.java
+++ b/strongback-testing/src/org/strongback/mock/MockController.java
@@ -1,0 +1,102 @@
+/*
+ * Strongback
+ * Copyright 2015, Strongback and individual contributors by the @authors tag.
+ * See the COPYRIGHT.txt in the distribution for a full listing of individual
+ * contributors.
+ *
+ * Licensed under the MIT License; you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.strongback.mock;
+
+import org.strongback.Executable;
+import org.strongback.control.Controller;
+
+/**
+ * A {@link Controller} implementation that tests can use to manually {@link #setValue(double) set the value}.
+ */
+public class MockController implements Controller {
+
+    private boolean enabled = true;
+    private double setpoint = 0.0d;
+    private double tolerance = 0.0d;
+    private double value = 0.0d;
+    private final Executable executable = (time)->computeOutput();
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public Controller enable() {
+        enabled = true;
+        return this;
+    }
+
+    @Override
+    public Controller disable() {
+        enabled = false;
+        return this;
+    }
+
+    @Override
+    public double getTarget() {
+        return setpoint;
+    }
+
+    @Override
+    public MockController withTarget(double target) {
+        this.setpoint = target;
+        return this;
+    }
+
+    @Override
+    public double getTolerance() {
+        return tolerance;
+    }
+
+    @Override
+    public MockController withTolerance(double tolerance) {
+        this.tolerance = tolerance;
+        return this;
+    }
+
+    @Override
+    public boolean computeOutput() {
+        return isWithinTolerance();
+    }
+
+    @Override
+    public MockController reset() {
+        return this;
+    }
+
+    @Override
+    public boolean hasExecutable() {
+        return true;
+    }
+
+    @Override
+    public Executable executable() {
+        return executable;
+    }
+
+    @Override
+    public double getValue() {
+        return value;
+    }
+
+    public MockController setValue( double value ) {
+        this.value = value;
+        return this;
+    }
+
+}

--- a/strongback-testing/src/org/strongback/mock/MockPIDController.java
+++ b/strongback-testing/src/org/strongback/mock/MockPIDController.java
@@ -1,0 +1,100 @@
+/*
+ * Strongback
+ * Copyright 2015, Strongback and individual contributors by the @authors tag.
+ * See the COPYRIGHT.txt in the distribution for a full listing of individual
+ * contributors.
+ *
+ * Licensed under the MIT License; you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.strongback.mock;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.strongback.control.Controller;
+import org.strongback.control.PIDController;
+
+/**
+ * A {@link Controller} implementation that tests can use to manually {@link #setValue(double) set the value}.
+ */
+public class MockPIDController extends MockController implements PIDController {
+
+    private volatile int currentProfile = PIDController.DEFAULT_PROFILE;
+    private final Map<Integer,Gains> profiles = new ConcurrentHashMap<>();
+
+    public MockPIDController() {
+        withGains(0.0,0.0,0.0);
+    }
+
+    @Override
+    public Set<Integer> getProfiles() {
+        return Collections.unmodifiableSet(profiles.keySet());
+    }
+
+    @Override
+    public synchronized MockPIDController withProfile(int profile, double p, double i, double d, double feedForward) {
+        profiles.put(profile, new Gains(p,i,d,feedForward));
+        return this;
+    }
+
+    @Override
+    public synchronized int getCurrentProfile() {
+        return currentProfile;
+    }
+
+    @Override
+    public synchronized Gains getGainsForCurrentProfile() {
+        return profiles.get(currentProfile);
+    }
+
+    @Override
+    public synchronized MockPIDController useProfile(int profile) {
+        if ( !profiles.containsKey(profile) ) throw new IllegalArgumentException("Invalid profile");
+        currentProfile = profile;
+        return this;
+    }
+
+    protected final class Gains implements PIDController.Gains {
+        protected final double p;
+        protected final double i;
+        protected final double d;
+        protected final double feedForward;
+
+        protected Gains(double p, double i, double d, double feedForward) {
+            this.p = p;
+            this.i = i;
+            this.d = d;
+            this.feedForward = feedForward;
+        };
+
+        @Override
+        public double getP() {
+            return p;
+        }
+
+        @Override
+        public double getI() {
+            return i;
+        }
+
+        @Override
+        public double getD() {
+            return d;
+        }
+
+        @Override
+        public double getFeedForward() {
+            return feedForward;
+        }
+    }
+}

--- a/strongback-testing/src/org/strongback/mock/MockPIDController.java
+++ b/strongback-testing/src/org/strongback/mock/MockPIDController.java
@@ -37,6 +37,18 @@ public class MockPIDController extends MockController implements PIDController {
     }
 
     @Override
+    public MockPIDController withTarget(double target) {
+        super.withTarget(target);
+        return this;
+    }
+
+    @Override
+    public MockPIDController withTolerance(double tolerance) {
+        super.withTolerance(tolerance);
+        return this;
+    }
+
+    @Override
     public Set<Integer> getProfiles() {
         return Collections.unmodifiableSet(profiles.keySet());
     }

--- a/strongback-testing/src/org/strongback/mock/MockTalonSRX.java
+++ b/strongback-testing/src/org/strongback/mock/MockTalonSRX.java
@@ -16,18 +16,26 @@
 
 package org.strongback.mock;
 
+import org.strongback.components.Fuse;
+import org.strongback.components.Switch;
 import org.strongback.components.TalonSRX;
+import org.strongback.components.TemperatureSensor;
+import org.strongback.components.VoltageSensor;
 
-/**
- * @author Randall Hauch
- *
- */
 public class MockTalonSRX extends MockMotor implements TalonSRX {
 
     private final MockAngleSensor encoder = new MockAngleSensor();
     private final MockCurrentSensor current = new MockCurrentSensor();
+    private final MockVoltageSensor voltage = new MockVoltageSensor();
+    private final MockVoltageSensor busVoltage = new MockVoltageSensor();
+    private final MockTemperatureSensor temperature = new MockTemperatureSensor();
     private final MockSwitch forwardLimitSwitch = new MockSwitch();
     private final MockSwitch reverseLimitSwitch = new MockSwitch();
+    private final StickyFaults stickyFaults = new StickyFaults();
+    private final MockFaults instantaneousFaults = new MockFaults(stickyFaults);
+    private boolean safetyEnabled = true;
+    private double expiration = 0.1d;
+    private boolean alive = true;
 
     protected MockTalonSRX(double speed) {
         super(speed);
@@ -50,6 +58,21 @@ public class MockTalonSRX extends MockMotor implements TalonSRX {
     }
 
     @Override
+    public VoltageSensor getVoltageSensor() {
+        return voltage;
+    }
+
+    @Override
+    public VoltageSensor getBusVoltageSensor() {
+        return busVoltage;
+    }
+
+    @Override
+    public TemperatureSensor getTemperatureSensor() {
+        return temperature;
+    }
+
+    @Override
     public MockSwitch getForwardLimitSwitch() {
         return forwardLimitSwitch;
     }
@@ -57,6 +80,202 @@ public class MockTalonSRX extends MockMotor implements TalonSRX {
     @Override
     public MockSwitch getReverseLimitSwitch() {
         return reverseLimitSwitch;
+    }
+
+    @Override
+    public TalonSRX setForwardSoftLimit(int forwardLimit) {
+        return this;
+    }
+
+    @Override
+    public TalonSRX enableForwardSoftLimit(boolean enable) {
+        return this;
+    }
+
+    @Override
+    public TalonSRX setReverseSoftLimit(int reverseLimit) {
+        return this;
+    }
+
+    @Override
+    public TalonSRX enableReverseSoftLimit(boolean enable) {
+        return this;
+    }
+
+    @Override
+    public TalonSRX enableLimitSwitch(boolean forward, boolean reverse) {
+        return this;
+    }
+
+    @Override
+    public TalonSRX setForwardLimitSwitchNormallyOpen(boolean normallyOpen) {
+        return this;
+    }
+
+    @Override
+    public TalonSRX setReverseLimitSwitchNormallyOpen(boolean normallyOpen) {
+        return this;
+    }
+
+    @Override
+    public TalonSRX enableBrakeMode(boolean brake) {
+        return this;
+    }
+
+    @Override
+    public MockFaults faults() {
+        return instantaneousFaults;
+    }
+
+    @Override
+    public StickyFaults stickyFaults() {
+        return stickyFaults;
+    }
+
+    @Override
+    public MockTalonSRX clearStickyFaults() {
+        stickyFaults.reset();
+        return this;
+    }
+
+    @Override
+    public long getFirmwareVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean isSafetyEnabled() {
+        return safetyEnabled;
+    }
+
+    @Override
+    public TalonSRX setSafetyEnabled(boolean enabled) {
+        safetyEnabled = enabled;
+        return this;
+    }
+
+    @Override
+    public TalonSRX setExpiration(double timeout) {
+        expiration = timeout;
+        return this;
+    }
+
+    @Override
+    public double getExpiration() {
+        return expiration;
+    }
+
+    @Override
+    public boolean isAlive() {
+        return alive;
+    }
+
+    public MockTalonSRX setAlive( boolean alive ) {
+        this.alive = alive;
+        if ( !alive ) stop();
+        return this;
+    }
+
+    private void triggerFault( MockSwitch stickySwitch ) {
+        // Any fault should always stop the motor ...
+        stickySwitch.setTriggered();
+        stop();
+    }
+
+    public class MockFaults implements Faults {
+        private final Fuse overTemperature;
+        private final Fuse underVoltage;
+        private final Fuse forwardSoftLimit;
+        private final Fuse reverseSoftLimit;
+        private final Fuse forwardLimitSwitch;
+        private final Fuse reverseLimitSwitch;
+        private final Fuse hardwareFailure;
+        protected MockFaults( StickyFaults sticky ) {
+            // These should trip the sticky faults and then immediately reset ...
+            overTemperature = Fuse.instantaneous(()->triggerFault(sticky.overTemperature));
+            underVoltage = Fuse.instantaneous(()->triggerFault(sticky.underVoltage));
+            forwardSoftLimit = Fuse.instantaneous(()->triggerFault(sticky.forwardSoftLimit));
+            reverseSoftLimit = Fuse.instantaneous(()->triggerFault(sticky.reverseSoftLimit));
+            forwardLimitSwitch = Fuse.instantaneous(()->triggerFault(sticky.forwardLimitSwitch));
+            reverseLimitSwitch = Fuse.instantaneous(()->triggerFault(sticky.reverseLimitSwitch));
+            hardwareFailure = Fuse.instantaneous(()->triggerFault(sticky.hardwareFailure));
+        }
+        @Override
+        public Fuse overTemperature() {
+            return overTemperature;
+        }
+        @Override
+        public Fuse underVoltage() {
+            return underVoltage;
+        }
+        @Override
+        public Fuse forwardSoftLimit() {
+            return forwardSoftLimit;
+        }
+        @Override
+        public Fuse reverseSoftLimit() {
+            return reverseSoftLimit;
+        }
+        @Override
+        public Fuse forwardLimitSwitch() {
+            return forwardLimitSwitch;
+        }
+        @Override
+        public Fuse reverseLimitSwitch() {
+            return reverseLimitSwitch;
+        }
+        @Override
+        public Fuse hardwareFailure() {
+            return hardwareFailure;
+        }
+    }
+
+    protected static class StickyFaults implements Faults {
+        protected final MockSwitch overTemperature = new MockSwitch().setNotTriggered();
+        protected final MockSwitch underVoltage = new MockSwitch().setNotTriggered();
+        protected final MockSwitch forwardSoftLimit = new MockSwitch().setNotTriggered();
+        protected final MockSwitch reverseSoftLimit = new MockSwitch().setNotTriggered();
+        protected final MockSwitch forwardLimitSwitch = new MockSwitch().setNotTriggered();
+        protected final MockSwitch reverseLimitSwitch = new MockSwitch().setNotTriggered();
+        protected final MockSwitch hardwareFailure = new MockSwitch().setNotTriggered();
+
+        @Override
+        public Switch overTemperature() {
+            return overTemperature;
+        }
+        @Override
+        public Switch underVoltage() {
+            return underVoltage;
+        }
+        @Override
+        public Switch forwardSoftLimit() {
+            return forwardSoftLimit;
+        }
+        @Override
+        public Switch reverseSoftLimit() {
+            return reverseSoftLimit;
+        }
+        @Override
+        public Switch forwardLimitSwitch() {
+            return forwardLimitSwitch;
+        }
+        @Override
+        public Switch reverseLimitSwitch() {
+            return reverseLimitSwitch;
+        }
+        @Override
+        public Switch hardwareFailure() {
+            return hardwareFailure;
+        }
+        protected void reset() {
+            overTemperature.setNotTriggered();
+            underVoltage.setNotTriggered();
+            forwardSoftLimit.setNotTriggered();
+            reverseSoftLimit.setNotTriggered();
+            forwardLimitSwitch.setNotTriggered();
+            reverseLimitSwitch.setNotTriggered();
+            hardwareFailure.setNotTriggered();
+        }
     }
 
 }

--- a/strongback-testing/src/org/strongback/mock/MockTalonSRX.java
+++ b/strongback-testing/src/org/strongback/mock/MockTalonSRX.java
@@ -17,6 +17,7 @@
 package org.strongback.mock;
 
 import org.strongback.components.Fuse;
+import org.strongback.components.Gyroscope;
 import org.strongback.components.Switch;
 import org.strongback.components.TalonSRX;
 import org.strongback.components.TemperatureSensor;
@@ -24,7 +25,12 @@ import org.strongback.components.VoltageSensor;
 
 public class MockTalonSRX extends MockMotor implements TalonSRX {
 
-    private final MockAngleSensor encoder = new MockAngleSensor();
+    private static final Gyroscope NO_OP_GYRO = new MockGyroscope();
+
+    private final int deviceId;
+    private final MockGyroscope encoderInput = new MockGyroscope();
+    private final MockGyroscope analogInput = new MockGyroscope();
+    private Gyroscope selectedInput = NO_OP_GYRO;
     private final MockCurrentSensor current = new MockCurrentSensor();
     private final MockVoltageSensor voltage = new MockVoltageSensor();
     private final MockVoltageSensor busVoltage = new MockVoltageSensor();
@@ -37,8 +43,14 @@ public class MockTalonSRX extends MockMotor implements TalonSRX {
     private double expiration = 0.1d;
     private boolean alive = true;
 
-    protected MockTalonSRX(double speed) {
+    protected MockTalonSRX(int deviceId, double speed) {
         super(speed);
+        this.deviceId = deviceId;
+    }
+
+    @Override
+    public int getDeviceID() {
+        return deviceId;
     }
 
     @Override
@@ -48,8 +60,51 @@ public class MockTalonSRX extends MockMotor implements TalonSRX {
     }
 
     @Override
-    public MockAngleSensor getAngleSensor() {
-        return encoder;
+    public MockGyroscope getAnalogInput() {
+        return analogInput;
+    }
+
+    @Override
+    public MockGyroscope getEncoderInput() {
+        return encoderInput;
+    }
+
+    @Override
+    public Gyroscope getSelectedSensor() {
+        return selectedInput;
+    }
+
+    @Override
+    public MockTalonSRX reverseSensor(boolean flip) {
+        return this;
+    }
+
+    @Override
+    public MockTalonSRX setFeedbackDevice(FeedbackDevice device) {
+        switch(device) {
+            case ANALOG_POTENTIOMETER:
+            case ANALOG_ENCODER:
+                this.selectedInput = analogInput;
+                break;
+            case QUADRATURE_ENCODER:
+                this.selectedInput = encoderInput;
+                break;
+            case ENCODER_FALLING:
+            case ENCODER_RISING:
+                selectedInput = NO_OP_GYRO;
+                break;
+        }
+        return this;
+    }
+
+    @Override
+    public MockTalonSRX setStatusFrameRate(StatusFrameRate frameRate, int periodMillis) {
+        return this;
+    }
+
+    @Override
+    public MockTalonSRX setVoltageRampRate(double rampRate) {
+        return this;
     }
 
     @Override

--- a/strongback-tests/src/org/strongback/hardware/HardwareTalonSRX_AnalogInputSensorTest.java
+++ b/strongback-tests/src/org/strongback/hardware/HardwareTalonSRX_AnalogInputSensorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Strongback
+ * Copyright 2015, Strongback and individual contributors by the @authors tag.
+ * See the COPYRIGHT.txt in the distribution for a full listing of individual
+ * contributors.
+ *
+ * Licensed under the MIT License; you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.strongback.hardware;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.fest.assertions.Delta;
+import org.junit.Before;
+import org.junit.Test;
+import org.strongback.hardware.HardwareTalonSRX.AnalogInputSensor;
+
+public class HardwareTalonSRX_AnalogInputSensorTest {
+
+    private static final Delta DELTA = Delta.delta(1);
+
+    private double analogPosition = 0.0;
+    private double analogVelocity = 0.0; // changes in volts per cycle
+    private double analogRange = 1023;   // 10 bit values
+    private double analogTurnsOverVoltageRange = 1;
+    private double analogVoltageRange = 3.3;
+    private double cyclePeriodInSeconds = 0.1;
+    private AnalogInputSensor sensor;
+
+    @Before
+    public void beforeEach() {
+    }
+
+    protected AnalogInputSensor createSensor() {
+        sensor = new AnalogInputSensor(() -> analogPosition,
+                                       () -> analogVelocity,
+                                       analogRange,
+                                       analogTurnsOverVoltageRange / analogVoltageRange,
+                                       analogVoltageRange,
+                                       () -> cyclePeriodInSeconds);
+        return sensor;
+    }
+
+    @Test
+    public void shouldReturnZeroWhenMeasuredPositionAndVelocityAreZero() {
+        analogPosition = 0;
+        analogTurnsOverVoltageRange = 1;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.rawPositionForAngleInDegrees(0.0d)).isEqualTo(analogPosition, DELTA);
+    }
+
+    @Test
+    public void shouldReturnZeroWhenMeasuredPositionIsHalfRotationAndVelocityAreZero() {
+        analogPosition = 1024/2 - 1;
+        analogTurnsOverVoltageRange = 1;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(180.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(180.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.rawPositionForAngleInDegrees(180.0d)).isEqualTo(analogPosition, DELTA);
+    }
+
+    @Test
+    public void shouldReturnZeroWhenMeasuredPositionIsOneRotationAndVelocityAreZero() {
+        analogPosition = 1024-1;
+        analogTurnsOverVoltageRange = 1;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(360.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.rawPositionForAngleInDegrees(360.0d)).isEqualTo(analogPosition, DELTA);
+    }
+
+    @Test
+    public void shouldReturnZeroWhenMeasuredPositionIsOneAndOneHalfRotationAndVelocityAreZero() {
+        analogPosition = (int)(1024 * 1.5) - 1;
+        analogTurnsOverVoltageRange = 1;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(540.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(180.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.rawPositionForAngleInDegrees(540.0d)).isEqualTo(analogPosition, DELTA);
+    }
+
+    @Test
+    public void shouldReturnZeroWhenMeasuredPositionIsThreeAndOneHalfRotationAndVelocityAreZero() {
+        analogPosition = (int)(1024 * 3.5) - 1;
+        analogTurnsOverVoltageRange = 1;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(1260.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(180.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.rawPositionForAngleInDegrees(1260.0d)).isEqualTo(analogPosition, Delta.delta(5.0));
+    }
+
+    @Test
+    public void shouldHandleMeasuredPositionAndVelocity() {
+        analogPosition = (int)(1024 * 3.5) - 1;
+        analogVelocity = 1023; // starts from 0 and does full rotation
+        analogTurnsOverVoltageRange = 1;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(1260.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(180.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(360.0 / cyclePeriodInSeconds, DELTA); // degrees per second
+        assertThat(sensor.rawPositionForAngleInDegrees(1260.0d)).isEqualTo(analogPosition, Delta.delta(5.0));
+    }
+
+}

--- a/strongback-tests/src/org/strongback/hardware/HardwareTalonSRX_EncoderInputSensorTest.java
+++ b/strongback-tests/src/org/strongback/hardware/HardwareTalonSRX_EncoderInputSensorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Strongback
+ * Copyright 2015, Strongback and individual contributors by the @authors tag.
+ * See the COPYRIGHT.txt in the distribution for a full listing of individual
+ * contributors.
+ *
+ * Licensed under the MIT License; you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.strongback.hardware;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.fest.assertions.Delta;
+import org.junit.Before;
+import org.junit.Test;
+import org.strongback.hardware.HardwareTalonSRX.EncoderInputSensor;
+
+public class HardwareTalonSRX_EncoderInputSensorTest {
+
+    private static final Delta DELTA = Delta.delta(0.00001);
+
+    private double positionInEdges = 0.0;
+    private double velocityInEdges = 0.0;
+    private double cyclePeriodInSeconds = 0.1;
+    private double rotationInDegrees = 0.0;
+    private int encoderPulsesPerRotation = 360;
+    private int encoderEdgesPerPulse = 4; // 4x mode, or 4 rising edges per pulse
+    private EncoderInputSensor sensor;
+
+    @Before
+    public void beforeEach() {
+        cyclePeriodInSeconds = 0.1;
+    }
+
+    protected EncoderInputSensor createSensor() {
+        sensor = new EncoderInputSensor(() -> positionInEdges, () -> velocityInEdges, encoderPulsesPerRotation / 360.0, // pulses
+                                                                                                                        // per
+                                                                                                                        // degree
+                encoderEdgesPerPulse, () -> cyclePeriodInSeconds);
+        return sensor;
+    }
+
+    @Test
+    public void shouldReturnZeroWhenMeasuredPositionAndVelocityAreZero() {
+        encoderPulsesPerRotation = 360;
+        positionInEdges = 0.0;
+        velocityInEdges = 0.0;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.rawPositionForAngleInDegrees(0.0d)).isEqualTo(positionInEdges, DELTA);
+    }
+
+    @Test
+    public void shouldReturnZeroWhenMeasuredPositionIsHalfRotationAndVelocityAreZero() {
+        encoderPulsesPerRotation = 360;
+        positionInEdges = 180 * 4;  // edges for 180 degrees
+        velocityInEdges = 0.0;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(180.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(180.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.rawPositionForAngleInDegrees(180.0d)).isEqualTo(positionInEdges, DELTA);
+    }
+
+    @Test
+    public void shouldReturnZeroWhenMeasuredPositionIsOneAndOneHalfRotationAndVelocityAreZero() {
+        encoderPulsesPerRotation = 360;
+        positionInEdges = (180+360) * 4;  // edges for 540 degrees
+        velocityInEdges = 0.0;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(540.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(180.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.rawPositionForAngleInDegrees(540.0d)).isEqualTo(positionInEdges, DELTA);
+    }
+
+    @Test
+    public void shouldReturnZeroWhenMeasuredPositionIsThreeAndOneHalfRotationAndVelocityAreZero() {
+        encoderPulsesPerRotation = 360;
+        positionInEdges = (180+360*3) * 4;  // edges for 1260 degrees
+        velocityInEdges = 0.0;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(1260.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(180.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.rawPositionForAngleInDegrees(1260.0d)).isEqualTo(positionInEdges, DELTA);
+    }
+
+    @Test
+    public void shouldReturnZeroWhenMeasuredPositionIsThreeAndOneHalfRotationAndVelocityAreZeroWithPrecisionEncoder() {
+        encoderPulsesPerRotation = 250;
+        rotationInDegrees = 180+360*3;
+        positionInEdges = rotationInDegrees * encoderPulsesPerRotation /360 * 4;
+        velocityInEdges = 0.0;
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(1260.0d, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(180.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.rawPositionForAngleInDegrees(1260.0d)).isEqualTo(positionInEdges, DELTA);
+    }
+
+    @Test
+    public void shouldHandleMeasuredPositionOfOneAndVelocityOfTwenty() {
+        double rotationsPerSecond = 20;
+        encoderPulsesPerRotation = 360;
+        rotationInDegrees = 360;
+        positionInEdges = rotationInDegrees * encoderPulsesPerRotation /360 * 4;
+        velocityInEdges = rotationsPerSecond * 4 * 360.0 * cyclePeriodInSeconds; // per cycle, or 28800 position units / second
+        createSensor();
+        assertThat(sensor.getAngle()).isEqualTo(360.0, DELTA);
+        assertThat(sensor.getHeading()).isEqualTo(0.0d, DELTA);
+        assertThat(sensor.getRate()).isEqualTo(rotationsPerSecond * 360.0, DELTA); // degrees per second
+        assertThat(sensor.rawPositionForAngleInDegrees(360.0d)).isEqualTo(positionInEdges, DELTA);
+    }
+
+}

--- a/strongback/src/org/strongback/components/TalonSRX.java
+++ b/strongback/src/org/strongback/components/TalonSRX.java
@@ -297,18 +297,27 @@ public interface TalonSRX extends LimitedMotor {
         /**
          * Use Quadrature Encoder.
          */
-        QUADRATURE_ENCODER(0), /**
-                                * Analog potentiometer, 0-3.3V
-                                */
-        ANALOG_POTENTIOMETER(2), /**
-                                  * Analog encoder or any other analog device, 0-3.3V
-                                  */
-        ANALOG_ENCODER(3), /**
-                            * Encoder that increments position per rising edge (and never decrements) on Quadrature-A.
-                            */
-        ENCODER_RISING(4), /**
-                            * Encoder that increments position per falling edge (and never decrements) on Quadrature-A.
-                            */
+        QUADRATURE_ENCODER(0),
+
+        /**
+         * Analog potentiometer or any other analog device, 0-3.3V
+         */
+        ANALOG_POTENTIOMETER(2),
+
+        /**
+         * Analog encoder or any other analog device, 0-3.3V
+         */
+        ANALOG_ENCODER(3),
+
+        /**
+         * Encoder that increments position per rising edge (and never decrements) on Quadrature-A.
+         */
+        ENCODER_RISING(4),
+
+        /**
+         * Encoder that increments position per falling edge (and never decrements) on Quadrature-A.
+         * Note: Was not supported in 2015 firmware, per the <a href="https://www.ctr-electronics.com/Talon%20SRX%20Software%20Reference%20Manual.pdf">Talon SRX Software Reference Manual</a>, section 21.3
+         */
         ENCODER_FALLING(5);
 
         public int value;
@@ -335,7 +344,65 @@ public interface TalonSRX extends LimitedMotor {
      * Types of status frame rates.
      */
     public enum StatusFrameRate {
-        GENERAL(0), FEEDBACK(1), QUADRATURE_ENCODER(2), ANALOG_TEMPERATURE_BATTERY_VOLTAGE(3);
+        /**
+         * The General Status frame has a default period of 10ms, and provides:
+         * <ul>
+         * <li>Closed Loop Error - the closed-loop target minus actual position/velocity.</li>
+         * <li>Throttle - the current 10bit motor output duty cycle (-1023 full reverse to +1023 full forward).</li>
+         * <li>Forward Limit Switch Pin State</li>
+         * <li>Reverse Limit Switch Pin State</li>
+         * <li>Fault bits</li>
+         * <li>Applied Control Mode</li>
+         * </ul>
+         */
+        GENERAL(0),
+
+        /**
+         * The Feedback Status frame has a default period of 20ms, and provides:
+         * <ul>
+         * <li>Sensor Position - position of the selected sensor</li>
+         * <li>Sensor Velocity - velocity of the selected sensor</li>
+         * <li>Motor Current</li>
+         * <li>Sticky Faults</li>
+         * <li>Brake Neutral State</li>
+         * <li>Motor Control Profile Select</li>
+         * </ul>
+         */
+        FEEDBACK(1),
+
+        /**
+         * The Quadrature Encoder Status frame has a default period of 100ms, and provides:
+         * <ul>
+         * <li>Encoder Position - position of the quadrature sensor</li>
+         * <li>Encoder Velocity - velocity of the selected sensor</li>
+         * <li>Number of rising edges counted on the Index Pin.</li>
+         * <li>Quad A pin state.</li>
+         * <li>Quad B pin state.</li>
+         * <li>Quad Index pin state.</li>
+         * </ul>
+         * The quadrature decoder is always engaged, whether the feedback device is selected or not, and whether a quadrature
+         * encoder is actually wired or not. This means that the Quadrature Encoder signals are always available in programming
+         * API regardless of how the Talon is used. The 100ms update rate is sufficient for logging, instrumentation and
+         * debugging. If a faster update rate is required the robot application can select the appropriate sensor and leverage
+         * the Sensor Position and Sensor Velocity sent over the {@link #FEEDBACK} frame every 20ms (by default).
+         */
+        QUADRATURE_ENCODER(2),
+
+        /**
+         * The Analog, Temperature, and Battery Voltage status frame has a default period of 100ms, and provides:
+         * <ul>
+         * <li>Analog Position - position of the analog sensor</li>
+         * <li>Analog Velocity - velocity of the analog sensor</li>
+         * <li>Temperature</li>
+         * <li>Battery Voltage</li>
+         * </ul>
+         * The Analog to Digital Converter is always engaged, whether the feedback device is selected or not, and whether an
+         * analog sensor is actually wired or not. This means that the Analog In signals are always available in programming API
+         * regardless of how the Talon is used. The 100ms update rate is sufficient for logging, instrumentation and debugging.
+         * If a faster update rate is required the robot application can select the appropriate sensor and leverage the Sensor
+         * Position and Sensor Velocity sent over the {@link #FEEDBACK} frame every 20ms (by default).
+         */
+        ANALOG_TEMPERATURE_BATTERY_VOLTAGE(3);
         public int value;
 
         public static StatusFrameRate valueOf(int value) {

--- a/strongback/src/org/strongback/components/TalonSRX.java
+++ b/strongback/src/org/strongback/components/TalonSRX.java
@@ -34,10 +34,233 @@ public interface TalonSRX extends LimitedMotor {
     public AngleSensor getAngleSensor();
 
     /**
-     * Get the Talon SRX's current sensor.
+     * Get the Talon SRX's output current sensor.
      *
-     * @return the current sensor; never null
+     * @return the output current sensor; never null
      */
     public CurrentSensor getCurrentSensor();
 
+    /**
+     * Get the Talon SRX's output voltage sensor.
+     *
+     * @return the output voltage sensor; never null
+     */
+    public VoltageSensor getVoltageSensor();
+
+    /**
+     * Get the Talon SRX's bus voltage.
+     *
+     * @return the bus voltage sensor; never null
+     */
+    public VoltageSensor getBusVoltageSensor();
+
+    /**
+     * Get the Talon SRX's temperature sensor.
+     *
+     * @return the temperature sensor; never null
+     */
+    public TemperatureSensor getTemperatureSensor();
+
+    /**
+     * Set the soft limit for forward motion, which will disable the motor when the sensor is out of range.
+     *
+     * @param forwardLimit the sensor limit beyond which the motor's forward direction should be halted.
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonSRX setForwardSoftLimit(int forwardLimit);
+
+    /**
+     * Enable the forward soft limit.
+     *
+     * @param enable <code>true</code> if the limit is to be enabled, or <code>false</code> otherwise
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonSRX enableForwardSoftLimit(boolean enable);
+
+    /**
+     * Set the soft limit for reverse motion, which will disable the motor when the sensor is out of range.
+     *
+     * @param reverseLimit the sensor limit beyond which the motor's reverse direction should be halted.
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonSRX setReverseSoftLimit(int reverseLimit);
+
+    /**
+     * Enable the reverse soft limit.
+     *
+     * @param enable <code>true</code> if the limit is to be enabled, or <code>false</code> otherwise
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonSRX enableReverseSoftLimit(boolean enable);
+
+    /**
+     * Enable the forward and reverse limit switches.
+     *
+     * @param forward <code>true</code> if the forward limit is to be enabled, or <code>false</code> otherwise
+     * @param reverse <code>true</code> if the reverse limit is to be enabled, or <code>false</code> otherwise
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonSRX enableLimitSwitch(boolean forward, boolean reverse);
+
+    /**
+     * Configure the forward limit switch to be normally open or normally closed. Talon will disable momentarily if the Talon's
+     * current setting is dissimilar to the caller's requested setting.
+     *
+     * Since Talon saves setting to flash this should only affect a given Talon initially during robot install.
+     *
+     * @param normallyOpen <code>true</code> for normally open, or <code>false</code> for normally closed.
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonSRX setForwardLimitSwitchNormallyOpen(boolean normallyOpen);
+
+    /**
+     * Configure the reverse limit switch to be normally open or normally closed. Talon will disable momentarily if the Talon's
+     * current setting is dissimilar to the caller's requested setting.
+     *
+     * Since Talon saves setting to flash this should only affect a given Talon initially during robot install.
+     *
+     * @param normallyOpen <code>true</code> for normally open, or <code>false</code> for normally closed.
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonSRX setReverseLimitSwitchNormallyOpen(boolean normallyOpen);
+
+    /**
+     * Enable the brake mode.
+     *
+     * @param brake <code>true</code> if the brake mode is to be enabled, or <code>false</code> otherwise
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonSRX enableBrakeMode(boolean brake);
+
+    /**
+     * Get the faults currently associated with the Talon controller. These state of these faults may change at any time based
+     * upon the state of the module, and so they cannot be manually cleared.
+     *
+     * @return the current faults; never null
+     * @see #stickyFaults()
+     */
+    public Faults faults();
+
+    /**
+     * Get the sticky faults associated with the Talon controller. Once these faults are triggered, they are only reset with
+     * #clearStickyFaults
+     *
+     * @return the sticky faults; never null
+     * @see #faults()
+     * @see #clearStickyFaults()
+     */
+    public Faults stickyFaults();
+
+    /**
+     * Clear all {@link #stickyFaults() sticky faults} that may have been triggered.
+     *
+     * @return this instance so that methods can be chained; never null
+     */
+    public TalonSRX clearStickyFaults();
+
+    /**
+     * Get the firmware version.
+     *
+     * @return the version of the firmware running on the Talon
+     */
+    public long getFirmwareVersion();
+
+    /**
+     * Determine whether this motor controller's safety mode is enabled.
+     *
+     * @return <code>true</code> if the motor will be automatically disabled if it is not used within the expiration time, or
+     *         <code>false</code> otherwise
+     */
+    public boolean isSafetyEnabled();
+
+    /**
+     * Set whether this motor controller's safety mode is enabled.
+     *
+     * @param enabled <code>true</code> if the motor will be automatically disabled if it is not used within the expiration
+     *        time, or <code>false</code> otherwise
+     * @return this instance so that methods can be chained; never null
+     */
+    public TalonSRX setSafetyEnabled(boolean enabled);
+
+    /**
+     * Get the motor safety expiration time in milliseconds. When {@link #isSafetyEnabled() safety is enabled}, then the motor
+     * will be automatically disabled if it is not used within the expiration time, which is typically 100ms. This can be
+     * adjusted to a larger value when debugging the robot.
+     *
+     * @return the safety expiration time in milliseconds
+     */
+    public double getExpiration();
+
+    /**
+     * Set the motor safety expiration time in milliseconds. When {@link #isSafetyEnabled() safety is enabled}, then the motor
+     * will be automatically disabled if it is not used within the expiration time, which is typically 100ms. This can be
+     * adjusted to a larger value when debugging the robot.
+     *
+     * @param timeout the safety expiration time in milliseconds
+     * @return this instance so that methods can be chained; never null
+     */
+    public TalonSRX setExpiration(double timeout);
+
+    /**
+     * Determine if this motor controller is alive or has been disabled because it has not been used within the
+     * {@link #getExpiration() expiration}.
+     *
+     * @return <code>true</code> if the controller is alive, or <code>false</code> if it has been disabled after expiring.
+     */
+    public boolean isAlive();
+
+    /**
+     * The set of possible faults that this module can trigger.
+     */
+    public static interface Faults {
+
+        /**
+         * The switch that is {@link Switch#isTriggered() triggered} when the Talon's over-temperature fault is tripped.
+         *
+         * @return the switch; never null
+         */
+        Switch overTemperature();
+
+        /**
+         * The switch that is {@link Switch#isTriggered() triggered} when the voltage is too low.
+         *
+         * @return the switch; never null
+         */
+        Switch underVoltage();
+
+        /**
+         * The switch that is {@link Switch#isTriggered() triggered} when the forward limit switch fault is tripped.
+         *
+         * @return the switch; never null
+         */
+        Switch forwardLimitSwitch();
+
+        /**
+         * The switch that is {@link Switch#isTriggered() triggered} when the reverse limit switch fault is tripped.
+         *
+         * @return the switch; never null
+         */
+        Switch reverseLimitSwitch();
+
+        /**
+         * The switch that is {@link Switch#isTriggered() triggered} when the forward soft limit is tripped.
+         *
+         * @return the switch; never null
+         */
+        Switch forwardSoftLimit();
+
+        /**
+         * The switch that is {@link Switch#isTriggered() triggered} when the reverse soft limit is tripped.
+         *
+         * @return the switch; never null
+         */
+        Switch reverseSoftLimit();
+
+        /**
+         * The switch that is {@link Switch#isTriggered() triggered} when a hardware fault occurs.
+         *
+         * @return the switch; never null
+         */
+        Switch hardwareFailure();
+    }
 }

--- a/strongback/src/org/strongback/components/TalonSRX.java
+++ b/strongback/src/org/strongback/components/TalonSRX.java
@@ -16,11 +16,18 @@
 
 package org.strongback.components;
 
+import org.strongback.annotation.Experimental;
+
 /**
  * A motor controlled by a Talon SRX with built-in current sensor, position (angle) sensor, and optional external limit switches
  * wired into the SRX so that it can automatically stop the forward and reverse directions when the limit switches are
  * triggered.
+ * <p>
+ * This class is currently experimental. It certainly works as a simple motor, but most of this interface exposes functionality
+ * of the Talon SRX motor controller, including various input sensors. Little beyond setting and reading the speed has been
+ * tested.
  */
+@Experimental
 public interface TalonSRX extends LimitedMotor {
 
     @Override
@@ -315,8 +322,10 @@ public interface TalonSRX extends LimitedMotor {
         ENCODER_RISING(4),
 
         /**
-         * Encoder that increments position per falling edge (and never decrements) on Quadrature-A.
-         * Note: Was not supported in 2015 firmware, per the <a href="https://www.ctr-electronics.com/Talon%20SRX%20Software%20Reference%20Manual.pdf">Talon SRX Software Reference Manual</a>, section 21.3
+         * Encoder that increments position per falling edge (and never decrements) on Quadrature-A. Note: Was not supported in
+         * 2015 firmware, per the
+         * <a href="https://www.ctr-electronics.com/Talon%20SRX%20Software%20Reference%20Manual.pdf">Talon SRX Software
+         * Reference Manual</a>, section 21.3
          */
         ENCODER_FALLING(5);
 

--- a/strongback/src/org/strongback/control/Controller.java
+++ b/strongback/src/org/strongback/control/Controller.java
@@ -16,7 +16,9 @@
 
 package org.strongback.control;
 
-import org.strongback.command.UnmanagedControllerCommand;
+import org.strongback.Executable;
+import org.strongback.Executor;
+import org.strongback.Strongback;
 import org.strongback.command.Requirable;
 
 /**
@@ -25,19 +27,69 @@ import org.strongback.command.Requirable;
  *
  * @author Randall Hauch
  * @see PIDController
- * @see UnmanagedControllerCommand
  */
 public interface Controller extends Requirable {
 
     /**
-     * Calculate the next controller output. This usually involves reading one or more inputs and computing the output based
-     * upon a model of the system.
+     * Determine if this controller is {@link #enable() enabled}.
      *
-     * @return <code>true</code> if the execution completed because it resulted in a value that is within the tolerance of the
-     *         setpoint, or <code>false</code> if this controller is not {@link #isEnabled() enabled} or has not yet reached the
-     *         setpoint given the tolerance
+     * @return <code>true</code> if enabled, or <code>false</code> otherwise
      */
-    public boolean computeOutput();
+    public boolean isEnabled();
+
+    /**
+    * Enable this controller so that it does read inputs, compute errors, and generate outputs when {@link #computeOutput()} is
+    * called.
+    *
+    * @return this object so that methods can be chained; never null
+    */
+   public Controller enable();
+
+   /**
+    * Disable this controller to <em>not</em> read inputs, compute errors, and generate outputs when {@link #computeOutput()}
+    * is called.
+    *
+    * @return this object so that methods can be chained; never null
+    */
+   public Controller disable();
+
+    /**
+     * Get the current measured value for this controller.
+     * @return the current value
+     */
+    public double getValue();
+
+    /**
+     * Get the target value for this controller.
+     * @return the target value
+     * @see #withTarget(double)
+     */
+    public double getTarget();
+
+    /**
+     * Sets the target value for this controller.
+     *
+     * @param target the desired setpoint that this controller will use as a target
+     * @return this object so that methods can be chained; never null
+     * @see #getTarget()
+     */
+    public Controller withTarget(double target);
+
+    /**
+     * Sets the absolute tolerance for this controller.
+     *
+     * @param tolerance the maximum absolute error which is tolerable in the units of the input object
+     * @return this object so that methods can be chained; never null
+     * @see #getTolerance()
+     */
+    public Controller withTolerance(double tolerance);
+
+    /**
+     * Get the absolute tolerance for this controller.
+     * @return the target value
+     * @see #withTolerance(double)
+     */
+    public double getTolerance();
 
     /**
      * Determines whether the supplied value is within the {@link #getTolerance() tolerance} of the {@link #getTarget() target}.
@@ -60,42 +112,14 @@ public interface Controller extends Requirable {
     }
 
     /**
-     * Get the current measured value for this controller.
-     * @return the current value
-     */
-    public double getValue();
-
-    /**
-     * Sets the target value for this controller.
+     * Calculate the next controller output. This usually involves reading one or more inputs and computing the output based
+     * upon a model of the system.
      *
-     * @param target the desired setpoint that this controller will use as a target
-     * @return this object so that methods can be chained; never null
-     * @see #getTarget()
+     * @return <code>true</code> if the execution completed because it resulted in a value that is within the tolerance of the
+     *         setpoint, or <code>false</code> if this controller is not {@link #isEnabled() enabled} or has not yet reached the
+     *         setpoint given the tolerance
      */
-    public Controller withTarget(double target);
-
-    /**
-     * Get the target value for this controller.
-     * @return the target value
-     * @see #withTarget(double)
-     */
-    public double getTarget();
-
-    /**
-     * Sets the absolute tolerance for this controller.
-     *
-     * @param tolerance the maximum absolute error which is tolerable in the units of the input object
-     * @return this object so that methods can be chained; never null
-     * @see #getTolerance()
-     */
-    public Controller withTolerance(double tolerance);
-
-    /**
-     * Get the absolute tolerance for this controller.
-     * @return the target value
-     * @see #withTolerance(double)
-     */
-    public double getTolerance();
+    public boolean computeOutput();
 
     /**
      * Reset any error values stored from previous {@link #computeOutput() executions}.
@@ -105,26 +129,25 @@ public interface Controller extends Requirable {
     public Controller reset();
 
     /**
-     * Determine if this controller is {@link #enable() enabled}.
-     *
-     * @return <code>true</code> if enabled, or <code>false</code> otherwise
+     * Return whether the {@link Executable} instance returned by {@link #executable()} does anything useful. Software-based
+     * controllers may often return <code>true</code>, whereas many hardware-based controllers may return <code>false</code>.
+     * @return <code>true</code> if the {@link #executable()} does useful work and enables the controller to operate
+     * continually and automatically, or <code>false</code> if the {@link #executable()} does nothing.
      */
-    public boolean isEnabled();
+    public default boolean hasExecutable() {
+        return true;
+    }
 
     /**
-     * Enable this controller so that it does read inputs, compute errors, and generate outputs when {@link #computeOutput()} is
-     * called.
+     * Get the {@link Executable} instance that will continuously {@link #computeOutput() execute} this controller to read
+     * inputs from the source and generate outputs to reach the {@link #getTarget() target}.
+     * <p>
+     * If this is used, then this same controller should <em>never</em> be used with commands. This is not checked, so robot
+     * programs are responsible for ensuring this does not happen.
      *
-     * @return this object so that methods can be chained; never null
+     * @return the {@link Executable} object that can be registered with an {@link Executor} (typically Strongback's
+     *         {@link Strongback#executor() central executor}); never null and always the same instance for this controller
      */
-    public Controller enable();
-
-    /**
-     * Disable this controller to <em>not</em> read inputs, compute errors, and generate outputs when {@link #computeOutput()}
-     * is called.
-     *
-     * @return this object so that methods can be chained; never null
-     */
-    public Controller disable();
+    public Executable executable();
 
 }

--- a/strongback/src/org/strongback/control/PIDController.java
+++ b/strongback/src/org/strongback/control/PIDController.java
@@ -41,6 +41,12 @@ public interface PIDController extends Controller {
      */
     public static int DEFAULT_PROFILE = 0;
 
+    @Override
+    public PIDController withTarget(double target);
+
+    @Override
+    public PIDController withTolerance(double tolerance);
+
     /**
      * Set the control gains on this controller's current profile.
      *

--- a/strongback/src/org/strongback/control/PIDController.java
+++ b/strongback/src/org/strongback/control/PIDController.java
@@ -49,7 +49,9 @@ public interface PIDController extends Controller {
      * @param d the differential gain
      * @return this object so that methods can be chained; never null
      */
-    public PIDController withGains(double p, double i, double d);
+    public default PIDController withGains(double p, double i, double d) {
+        return withGains(p, i, d, 0.0);
+    }
 
     /**
      * Set the control gains on this controller's current profile.
@@ -60,7 +62,9 @@ public interface PIDController extends Controller {
      * @param feedForward the feed-forward gain
      * @return this object so that methods can be chained; never null
      */
-    public PIDController withGains(double p, double i, double d, double feedForward);
+    public default PIDController withGains(double p, double i, double d, double feedForward) {
+        return withProfile(getCurrentProfile(), p, i, d, 0.0);
+    }
 
     /**
      * Get the set of profile numbers.
@@ -82,7 +86,9 @@ public interface PIDController extends Controller {
      * @return this object so that methods can be chained; never null
      * @throws IllegalArgumentException if the profile name is null
      */
-    public PIDController withProfile(int profile, double p, double i, double d);
+    public default PIDController withProfile(int profile, double p, double i, double d) {
+        return withProfile(profile,p,i,d,0.0);
+    }
 
     /**
      * Set the control gains for the specified profile, which may or may not be the current profile. Profile numbers start from

--- a/strongback/src/org/strongback/control/SoftwarePIDController.java
+++ b/strongback/src/org/strongback/control/SoftwarePIDController.java
@@ -146,6 +146,7 @@ public class SoftwarePIDController implements LiveWindowSendable, PIDController 
      * @return the {@link Executable} object that can be registered with an {@link Executor} (typically Strongback's
      *         {@link Strongback#executor() central executor}); never null and always the same instance for this controller
      */
+    @Override
     public Executable executable() {
         return executable;
     }
@@ -224,9 +225,8 @@ public class SoftwarePIDController implements LiveWindowSendable, PIDController 
     @Override
     public SoftwarePIDController withProfile(int profile, double p, double i, double d, double feedForward) {
         synchronized (this) {
-            Gains newGains = this.gainsByProfile.compute(profile, (key, gains) -> {
-                return new Gains(p, i, d, feedForward);
-            });
+            Gains newGains = new Gains(p, i, d, feedForward);
+            this.gainsByProfile.put(profile, newGains);
             if (profile == this.currentProfile) {
                 this.gains = newGains;
                 onTable(table -> {
@@ -524,10 +524,7 @@ public class SoftwarePIDController implements LiveWindowSendable, PIDController 
         return gains.feedForward;
     }
 
-    /**
-     * A set of gains.
-     */
-    private static final class Gains implements PIDController.Gains {
+    protected final class Gains implements PIDController.Gains {
         protected final double p;
         protected final double i;
         protected final double d;
@@ -540,41 +537,21 @@ public class SoftwarePIDController implements LiveWindowSendable, PIDController 
             this.feedForward = feedForward;
         };
 
-        /**
-         * Get the proportional gain.
-         *
-         * @return the proportional gain.
-         */
         @Override
         public double getP() {
             return p;
         }
 
-        /**
-         * Get the integral gain.
-         *
-         * @return the integral gain.
-         */
         @Override
         public double getI() {
             return i;
         }
 
-        /**
-         * Get the differential gain.
-         *
-         * @return the differential gain.
-         */
         @Override
         public double getD() {
             return d;
         }
 
-        /**
-         * Get the feed forward gain.
-         *
-         * @return the feed forward gain.
-         */
         @Override
         public double getFeedForward() {
             return feedForward;

--- a/strongback/src/org/strongback/control/SoftwarePIDController.java
+++ b/strongback/src/org/strongback/control/SoftwarePIDController.java
@@ -524,7 +524,7 @@ public class SoftwarePIDController implements LiveWindowSendable, PIDController 
         return gains.feedForward;
     }
 
-    protected final class Gains implements PIDController.Gains {
+    protected static final class Gains implements PIDController.Gains {
         protected final double p;
         protected final double i;
         protected final double d;

--- a/strongback/src/org/strongback/control/TalonController.java
+++ b/strongback/src/org/strongback/control/TalonController.java
@@ -1,0 +1,313 @@
+/*
+ * Strongback
+ * Copyright 2015, Strongback and individual contributors by the @authors tag.
+ * See the COPYRIGHT.txt in the distribution for a full listing of individual
+ * contributors.
+ *
+ * Licensed under the MIT License; you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.strongback.control;
+
+import org.strongback.components.TalonSRX;
+
+/**
+ * The Talon SRX Proportional Integral Differential (PID) controller with optional support for feed forward.
+ */
+public interface TalonController extends PIDController, TalonSRX {
+
+    /**
+     * A set of gains.
+     */
+    public static interface Gains extends PIDController.Gains {
+
+        /**
+         * Get the IZone value for the current profile of this controller. When IZone is used, the controller will automatically
+         * clear the integral accumulated error if the closed loop error is outside the IZone.
+         *
+         * @return the IZone value
+         */
+        public double getIzone();
+
+        /**
+         * Get the closed loop ramp rate for the current profile of this controller.
+         *
+         * @return the feed forward gain
+         */
+        public double getCloseLoopRampRate();
+    }
+
+    /**
+     * The type of control input used by this Talon controller.
+     */
+    public static enum ControlMode {
+        /**
+         * Directly control the motor by setting the speed as percent voltage, from -1.0 to 1.0 with 0.0 as stopped.
+         */
+        PERCENT_VBUS(0),
+        /**
+         * Control the motor by directly setting the desired position (in ticks or an analog value) for the motor's encoder.
+         */
+        POSITION(1),
+        /**
+         * Control the motor's speed in position change every 10 milliseconds.
+         */
+        SPEED(2),
+        /**
+         * Control the motor by directly setting the current to be sent to the motor.
+         */
+        CURRENT(3),
+        /**
+         * Control the motor by directly setting the voltage to be sent to the motor.
+         */
+        VOLTAGE(4),
+        /**
+         * Control the motor by following another Talon SRX device.
+         */
+        FOLLOWER(5);
+
+        private final int value;
+
+        public static ControlMode valueOf(int value) {
+            for (ControlMode mode : values()) {
+                if (mode.value == value) {
+                    return mode;
+                }
+            }
+            return null;
+        }
+
+        private ControlMode(int value) {
+            this.value = value;
+        }
+
+        public int value() {
+            return this.value;
+        }
+    }
+
+    /**
+     * The type of control sensor used by this Talon controller.
+     */
+    public enum FeedbackDevice {
+        /**
+         * Use Quadrature Encoder.
+         */
+        QUADRATURE_ENCODER(0),
+        /**
+         * Analog potentiometer, 0-3.3V
+         */
+        ANALOG_POTENTIOMETER(2),
+        /**
+         * Analog encoder, 0-3.3V
+         */
+        ANALOG_ENCODER(3),
+        /**
+         * Encoder that increment position per rising edge on Quadrature-A.
+         */
+        ENCODER_RISING(4),
+        /**
+         * Encoder that increment position per falling edge on Quadrature-A.
+         */
+        ENCODER_FALLING(5);
+
+        public int value;
+
+        public static FeedbackDevice valueOf(int value) {
+            for (FeedbackDevice mode : values()) {
+                if (mode.value == value) {
+                    return mode;
+                }
+            }
+            return null;
+        }
+
+        private FeedbackDevice(int value) {
+            this.value = value;
+        }
+
+        public int value() {
+            return this.value;
+        }
+    }
+
+    /**
+     * Types of status frame rates.
+     */
+    public enum StatusFrameRate {
+        GENERAL(0), FEEDBACK(1), QUADRATURE_ENCODER(2), ANALOG_TEMP_VBAT(3);
+        public int value;
+
+        public static StatusFrameRate valueOf(int value) {
+            for (StatusFrameRate mode : values()) {
+                if (mode.value == value) {
+                    return mode;
+                }
+            }
+            return null;
+        }
+
+        private StatusFrameRate(int value) {
+            this.value = value;
+        }
+
+        public int value() {
+            return this.value;
+        }
+    }
+
+    /**
+     * Get the CAN device ID.
+     *
+     * @return the device ID.
+     */
+    public int getDeviceID();
+
+    /**
+     * Get this controller's current control mode.
+     *
+     * @return the control mode; never null
+     */
+    public ControlMode getControlMode();
+
+    /**
+     * Set the control mode for this controller.
+     *
+     * @param mode the control mode; may not be null
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonController setControlMode(ControlMode mode);
+
+    /**
+     * Set the feedback device for this controller.
+     *
+     * @param device the feedback device; may not be null
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonController setFeedbackDevice(FeedbackDevice device);
+
+    /**
+     * Set the status frame rate for this controller.
+     *
+     * @param frameRate the status frame rate; may not be null
+     * @param periodMillis frame rate period in milliseconds
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonController setStatusFrameRate(StatusFrameRate frameRate, int periodMillis);
+
+    /**
+     * Flips the sign (multiplies by negative one) the sensor values going into the talon.
+     *
+     * This only affects position and velocity closed loop control. Allows for situations where you may have a sensor flipped
+     * and going in the wrong direction.
+     *
+     * @param flip <code>true</code> if sensor input should be flipped, or <code>false</code> if not.
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonController reverseSensor(boolean flip);
+
+    /**
+     * Flips the sign (multiplies by negative one) the throttle values going into the motor on the talon in closed loop modes.
+     *
+     * @param flip <code>true</code> if motor output should be flipped; or <code>false</code> if not.
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonController reverseOutput(boolean flip);
+
+    @Override
+    public TalonController setForwardSoftLimit(int forwardLimit);
+
+    @Override
+    public TalonController enableForwardSoftLimit(boolean enable);
+
+    @Override
+    public TalonController setReverseSoftLimit(int reverseLimit);
+
+    @Override
+    public TalonController enableReverseSoftLimit(boolean enable);
+
+    @Override
+    public TalonController enableLimitSwitch(boolean forward, boolean reverse);
+
+    @Override
+    public TalonController setForwardLimitSwitchNormallyOpen(boolean normallyOpen);
+
+    @Override
+    public TalonController setReverseLimitSwitchNormallyOpen(boolean normallyOpen);
+
+    @Override
+    public TalonController enableBrakeMode(boolean brake);
+
+    @Override
+    public TalonController withGains(double p, double i, double d);
+
+    @Override
+    public TalonController withGains(double p, double i, double d, double feedForward);
+
+    /**
+     * Set the gains for the current profile of this controller.
+     *
+     * @param p the proportional gain
+     * @param i the integral gain
+     * @param d the differential gain
+     * @param feedForward the feed-forward gain
+     * @param izone Integration zone -- prevents accumulation of integration error with large errors. Setting this to zero will
+     *        ignore any izone stuff.
+     * @param closeLoopRampRate Closed loop ramp rate. Maximum change in voltage, in volts / sec.
+     * @return this object so that methods can be chained; never null
+     * @see #useProfile(int)
+     */
+    public TalonController withGains(double p, double i, double d, double feedForward, int izone, double closeLoopRampRate);
+
+    @Override
+    public TalonController withProfile(int profile, double p, double i, double d);
+
+    @Override
+    public TalonController withProfile(int profile, double p, double i, double d, double feedForward);
+
+    /**
+     * Set the gains for the specified profile of this controller.
+     *
+     * @param profile which profile to set the PID constants for. You can have two profiles, with values of 0 or 1, allowing you
+     *        to keep a second set of values on hand in the Talon. In order to switch profiles without recalling setPID, you
+     *        must call setProfile().
+     * @param p the proportional gain
+     * @param i the integral gain
+     * @param d the differential gain
+     * @param feedForward the feed-forward gain
+     * @param izone Integration zone -- prevents accumulation of integration error with large errors. Setting this to zero will
+     *        ignore any izone stuff.
+     * @param closeLoopRampRate Closed loop ramp rate. Maximum change in voltage, in volts / sec.
+     * @return this object so that methods can be chained; never null
+     * @see #useProfile(int)
+     */
+    public TalonController withProfile(int profile, double p, double i, double d, double feedForward, int izone, double closeLoopRampRate);
+
+    @Override
+    public Gains getGainsForCurrentProfile();
+
+    /**
+     * Set the voltage ramp rate for the current profile of this controller. It limits the rate at which the throttle will
+     * change. Affects all modes.
+     *
+     * @param rampRate Maximum change in voltage, in volts / second
+     * @return this object so that methods can be chained; never null
+     */
+    public TalonController setVoltageRampRate(double rampRate);
+
+    @Override
+    public TalonController clearStickyFaults();
+
+    @Override
+    public TalonController setSafetyEnabled(boolean enabled);
+
+    @Override
+    public TalonController setExpiration(double timeout);
+}

--- a/strongback/src/org/strongback/control/TalonController.java
+++ b/strongback/src/org/strongback/control/TalonController.java
@@ -16,6 +16,7 @@
 
 package org.strongback.control;
 
+import org.strongback.annotation.Experimental;
 import org.strongback.components.TalonSRX;
 
 /**
@@ -85,7 +86,12 @@ import org.strongback.components.TalonSRX;
  *
  * The {@link #reverseOutput(boolean)} method can be used to invert the output of a follower Talon. This may be useful if a
  * follower and leader Talon are wired out of phase with each other.
+ * <p>
+ * This class is currently experimental. It certainly works as a simple motor, but most of this interface exposes functionality
+ * of the Talon SRX motor controller, including various input sensors. Little beyond setting and reading the speed has been
+ * tested.
  */
+@Experimental
 public interface TalonController extends PIDController, TalonSRX {
 
     /**

--- a/strongback/src/org/strongback/control/TalonController.java
+++ b/strongback/src/org/strongback/control/TalonController.java
@@ -172,6 +172,25 @@ public interface TalonController extends PIDController, TalonSRX {
     @Override
     public TalonController setFeedbackDevice(FeedbackDevice device);
 
+    /**
+     * Get the current target angle for this controller as defined by the selected input sensor in degrees.
+     * @return the target angle in degrees as defined by the selected input sensor
+     * @see #withTarget(double)
+     */
+    @Override
+    public double getTarget();
+
+    /**
+     * Sets the target angle for the controller's selected input sensor in degrees.
+     *
+     * @param angleInDegrees the desired angle in degrees that this controller will use as a target as defined by the selected
+     *        input sensor
+     * @return this object so that methods can be chained; never null
+     * @see #getTarget()
+     */
+    @Override
+    public TalonController withTarget(double angleInDegrees);
+
     @Override
     public TalonController setStatusFrameRate(StatusFrameRate frameRate, int periodMillis);
 

--- a/strongback/src/org/strongback/hardware/Hardware.java
+++ b/strongback/src/org/strongback/hardware/Hardware.java
@@ -16,6 +16,7 @@
 
 package org.strongback.hardware;
 
+import org.strongback.annotation.Experimental;
 import org.strongback.components.Accelerometer;
 import org.strongback.components.AngleSensor;
 import org.strongback.components.DistanceSensor;
@@ -547,6 +548,7 @@ public class Hardware {
          * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft; may be 0 if unused
          * @return a {@link TalonSRX} motor; never null
          */
+        @Experimental
         public static TalonSRX talonSRX(int deviceNumber, double pulsesPerDegree) {
             return talonSRX(deviceNumber, pulsesPerDegree, 0.0d);
         }
@@ -565,9 +567,24 @@ public class Hardware {
          *        be 0 if unused
          * @return a {@link TalonSRX} motor; never null
          */
+        @Experimental
         public static TalonSRX talonSRX(int deviceNumber, double pulsesPerDegree, double analogTurnsOverVoltageRange) {
             CANTalon talon = new CANTalon(deviceNumber);
             return talonSRX(talon, pulsesPerDegree, analogTurnsOverVoltageRange);
+        }
+
+        /**
+         * Creates a {@link TalonSRX} motor controlled by a Talon SRX. The {@link CANTalon} object passed into this method
+         * should be already configured by the calling code.
+         * <p>
+         * The resulting {@link TalonSRX} will have a null {@link TalonSRX#getEncoderInput()} and a null
+         * {@link TalonSRX#getAnalogInput()}, and the {@link TalonSRX#getSelectedSensor()} will always return 0.
+         *
+         * @param talon the already configured {@link CANTalon} instance; may not be null
+         * @return a {@link TalonSRX} motor; never null
+         */
+        public static TalonSRX talonSRX(CANTalon talon) {
+            return talonSRX(talon, 0.0, 0.0d);
         }
 
         /**
@@ -582,6 +599,7 @@ public class Hardware {
          * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft
          * @return a {@link TalonSRX} motor; never null
          */
+        @Experimental
         public static TalonSRX talonSRX(CANTalon talon, double pulsesPerDegree) {
             return talonSRX(talon, pulsesPerDegree, 0.0d);
         }
@@ -601,6 +619,7 @@ public class Hardware {
          *        be 0 if unused
          * @return a {@link TalonSRX} motor; never null
          */
+        @Experimental
         public static TalonSRX talonSRX(CANTalon talon, double pulsesPerDegree, double analogTurnsOverVoltageRange) {
             if (talon == null) throw new IllegalArgumentException("The CANTalon reference may not be null");
             return new HardwareTalonSRX(talon, pulsesPerDegree, analogTurnsOverVoltageRange);
@@ -644,6 +663,7 @@ public class Hardware {
          *        be 0 if unused
          * @return the interface for managing and using the Talon SRX hardware-based PID controller; never null
          */
+        @Experimental
         public static TalonController talonController(int deviceNumber, double pulsesPerDegree,
                 double analogTurnsOverVoltageRange) {
             CANTalon talon = new CANTalon(deviceNumber);

--- a/strongback/src/org/strongback/hardware/Hardware.java
+++ b/strongback/src/org/strongback/hardware/Hardware.java
@@ -567,7 +567,7 @@ public class Hardware {
          */
         public static TalonSRX talonSRX(int deviceNumber, double pulsesPerDegree, double analogTurnsOverVoltageRange) {
             CANTalon talon = new CANTalon(deviceNumber);
-            return new HardwareTalonSRX(talon, pulsesPerDegree, analogTurnsOverVoltageRange);
+            return talonSRX(talon, pulsesPerDegree, analogTurnsOverVoltageRange);
         }
 
         /**

--- a/strongback/src/org/strongback/hardware/Hardware.java
+++ b/strongback/src/org/strongback/hardware/Hardware.java
@@ -32,6 +32,7 @@ import org.strongback.components.TwoAxisAccelerometer;
 import org.strongback.components.ui.FlightStick;
 import org.strongback.components.ui.Gamepad;
 import org.strongback.components.ui.InputDevice;
+import org.strongback.control.TalonController;
 import org.strongback.function.DoubleToDoubleFunction;
 import org.strongback.util.Values;
 
@@ -524,6 +525,19 @@ public class Hardware {
          * Creates a {@link TalonSRX} motor controlled by a Talon SRX with built-in current sensor and position (angle) sensor.
          * The {@link CANTalon} object passed into this method should be already configured by the calling code.
          *
+         * @param deviceNumber the CAN device number; may not be null
+         * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft
+         * @return a {@link TalonSRX} motor; never null
+         */
+        public static TalonSRX talonSRX(int deviceNumber, double pulsesPerDegree) {
+            CANTalon talon = new CANTalon(deviceNumber);
+            return new HardwareTalonSRX(talon, pulsesPerDegree);
+        }
+
+        /**
+         * Creates a {@link TalonSRX} motor controlled by a Talon SRX with built-in current sensor and position (angle) sensor.
+         * The {@link CANTalon} object passed into this method should be already configured by the calling code.
+         *
          * @param talon the already configured {@link CANTalon} instance; may not be null
          * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft
          * @return a {@link TalonSRX} motor; never null
@@ -531,6 +545,25 @@ public class Hardware {
         public static TalonSRX talonSRX(CANTalon talon, double pulsesPerDegree) {
             if (talon == null) throw new IllegalArgumentException("The CANTalon reference may not be null");
             return new HardwareTalonSRX(talon, pulsesPerDegree);
+        }
+    }
+
+    /**
+     * Factory method for hardware-based controllers.
+     */
+    public static final class Controllers {
+
+        /**
+         * Create a component that manages and uses the hardware-based PID controller on the Talon SRX with the given CAN device
+         * number.
+         *
+         * @param deviceNumber the CAN device number; may not be null
+         * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft
+         * @return the interface for managing and using the Talon SRX hardware-based PID controller; never null
+         */
+        public static TalonController talonController(int deviceNumber, double pulsesPerDegree) {
+            CANTalon talon = new CANTalon(deviceNumber);
+            return new HardwareTalonController(talon, pulsesPerDegree);
         }
     }
 

--- a/strongback/src/org/strongback/hardware/Hardware.java
+++ b/strongback/src/org/strongback/hardware/Hardware.java
@@ -44,6 +44,7 @@ import edu.wpi.first.wpilibj.AnalogPotentiometer;
 import edu.wpi.first.wpilibj.AnalogTrigger;
 import edu.wpi.first.wpilibj.BuiltInAccelerometer;
 import edu.wpi.first.wpilibj.CANTalon;
+import edu.wpi.first.wpilibj.CANTalon.ControlMode;
 import edu.wpi.first.wpilibj.Compressor;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.DoubleSolenoid;
@@ -522,29 +523,105 @@ public class Hardware {
         }
 
         /**
-         * Creates a {@link TalonSRX} motor controlled by a Talon SRX with built-in current sensor and position (angle) sensor.
-         * The {@link CANTalon} object passed into this method should be already configured by the calling code.
+         * Creates a {@link TalonSRX} motor controlled by a Talon SRX with no sensors wired as inputs.
+         * <p>
+         * The resulting {@link TalonSRX} will have a null {@link TalonSRX#getAnalogInput()} and a null
+         * {@link TalonSRX#getEncoderInput()}.
          *
-         * @param deviceNumber the CAN device number; may not be null
-         * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft
+         * @param deviceNumber the CAN device number for the Talon SRX; may not be null
          * @return a {@link TalonSRX} motor; never null
          */
-        public static TalonSRX talonSRX(int deviceNumber, double pulsesPerDegree) {
-            CANTalon talon = new CANTalon(deviceNumber);
-            return new HardwareTalonSRX(talon, pulsesPerDegree);
+        public static TalonSRX talonSRX(int deviceNumber) {
+            return talonSRX(deviceNumber, 0.0d, 0.0d);
         }
 
         /**
-         * Creates a {@link TalonSRX} motor controlled by a Talon SRX with built-in current sensor and position (angle) sensor.
-         * The {@link CANTalon} object passed into this method should be already configured by the calling code.
+         * Creates a {@link TalonSRX} motor controlled by a Talon SRX with an optional quadrature encoder and no analog input
+         * wired into the Talon.
+         * <p>
+         * The resulting {@link TalonSRX} will have a non-null {@link TalonSRX#getEncoderInput()} when the
+         * <code>pulsesPerDegree</code> is non-zero. But the resulting {@link TalonSRX} will always have a null
+         * {@link TalonSRX#getAnalogInput()}.
+         *
+         * @param deviceNumber the CAN device number for the Talon SRX; may not be null
+         * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft; may be 0 if unused
+         * @return a {@link TalonSRX} motor; never null
+         */
+        public static TalonSRX talonSRX(int deviceNumber, double pulsesPerDegree) {
+            return talonSRX(deviceNumber, pulsesPerDegree, 0.0d);
+        }
+
+        /**
+         * Creates a {@link TalonSRX} motor controlled by a Talon SRX with an optional quadrature encoder and no an analog 3.3V
+         * input wired into the Talon.
+         * <p>
+         * The resulting {@link TalonSRX} will have a non-null {@link TalonSRX#getEncoderInput()} when the
+         * <code>pulsesPerDegree</code> is non-zero. Likewise, the resulting {@link TalonSRX} will have a non-null
+         * {@link TalonSRX#getAnalogInput()} when the <code>analogTurnsOverVoltageRange</code> is non-zero.
+         *
+         * @param deviceNumber the CAN device number for the Talon SRX; may not be null
+         * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft; may be 0 if unused
+         * @param analogTurnsOverVoltageRange the number of turns of an analog pot or analog encoder over the 0-3.3V range; may
+         *        be 0 if unused
+         * @return a {@link TalonSRX} motor; never null
+         */
+        public static TalonSRX talonSRX(int deviceNumber, double pulsesPerDegree, double analogTurnsOverVoltageRange) {
+            CANTalon talon = new CANTalon(deviceNumber);
+            return new HardwareTalonSRX(talon, pulsesPerDegree, analogTurnsOverVoltageRange);
+        }
+
+        /**
+         * Creates a {@link TalonSRX} motor controlled by a Talon SRX with an optional (angle) sensor. The {@link CANTalon}
+         * object passed into this method should be already configured by the calling code.
+         * <p>
+         * The resulting {@link TalonSRX} will have a non-null {@link TalonSRX#getEncoderInput()} when the
+         * <code>pulsesPerDegree</code> is non-zero. But the resulting {@link TalonSRX} will always have a null
+         * {@link TalonSRX#getAnalogInput()}.
          *
          * @param talon the already configured {@link CANTalon} instance; may not be null
          * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft
          * @return a {@link TalonSRX} motor; never null
          */
         public static TalonSRX talonSRX(CANTalon talon, double pulsesPerDegree) {
+            return talonSRX(talon, pulsesPerDegree, 0.0d);
+        }
+
+        /**
+         * Creates a {@link TalonSRX} motor controlled by a Talon SRX with and optional quadrature encoder and/or an analog 3.3V
+         * input wired into the Talon. The {@link CANTalon} object passed into this method should be already configured by the
+         * calling code.
+         * <p>
+         * The resulting {@link TalonSRX} will have a non-null {@link TalonSRX#getEncoderInput()} when the
+         * <code>pulsesPerDegree</code> is non-zero. Likewise, the resulting {@link TalonSRX} will have a non-null
+         * {@link TalonSRX#getAnalogInput()} when the <code>analogTurnsOverVoltageRange</code> is non-zero.
+         *
+         * @param talon the already configured {@link CANTalon} instance; may not be null
+         * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft
+         * @param analogTurnsOverVoltageRange the number of turns of an analog pot or analog encoder over the 0-3.3V range; may
+         *        be 0 if unused
+         * @return a {@link TalonSRX} motor; never null
+         */
+        public static TalonSRX talonSRX(CANTalon talon, double pulsesPerDegree, double analogTurnsOverVoltageRange) {
             if (talon == null) throw new IllegalArgumentException("The CANTalon reference may not be null");
-            return new HardwareTalonSRX(talon, pulsesPerDegree);
+            return new HardwareTalonSRX(talon, pulsesPerDegree, analogTurnsOverVoltageRange);
+        }
+
+        /**
+         * Creates a {@link TalonSRX} motor controller that follows another Talon SRX. The resulting TalonSRX will have neither
+         * a {@link TalonSRX#getAnalogInput()} or a {@link TalonSRX#getEncoderInput()}.
+         *
+         * @param deviceNumber the CAN device number for the Talon SRX; may not be null
+         * @param leader the Talon SRX that is to be followed; may not be null
+         * @param reverse <code>true</code> if the resulting Talon should have inverted output compared to the leader, or
+         *        <code>false</code> if the output should exactly match the leader
+         * @return a {@link TalonSRX} motor controller that follows the leader; never null
+         */
+        public static TalonSRX talonSRX(int deviceNumber, TalonSRX leader, boolean reverse) {
+            CANTalon talon = new CANTalon(deviceNumber);
+            talon.changeControlMode(ControlMode.Follower);
+            talon.set(leader.getDeviceID());
+            talon.reverseOutput(reverse);
+            return talonSRX(talon, 0.0d, 0.0d);
         }
     }
 
@@ -554,16 +631,24 @@ public class Hardware {
     public static final class Controllers {
 
         /**
-         * Create a component that manages and uses the hardware-based PID controller on the Talon SRX with the given CAN device
-         * number.
+         * Create a component that manages and uses the hardware-based PID controller on the Talon SRX with a quadrature encoder
+         * and/or an analog 3.3V input sensor wired into the Talon.
+         * <p>
+         * The resulting {@link TalonSRX} will have a non-null {@link TalonSRX#getEncoderInput()} when the
+         * <code>pulsesPerDegree</code> is non-zero. Likewise, the resulting {@link TalonSRX} will have a non-null
+         * {@link TalonSRX#getAnalogInput()} when the <code>analogTurnsOverVoltageRange</code> is non-zero.
          *
          * @param deviceNumber the CAN device number; may not be null
          * @param pulsesPerDegree the number of encoder pulses per degree of revolution of the final shaft
+         * @param analogTurnsOverVoltageRange the number of turns of an analog pot or analog encoder over the 0-3.3V range; may
+         *        be 0 if unused
          * @return the interface for managing and using the Talon SRX hardware-based PID controller; never null
          */
-        public static TalonController talonController(int deviceNumber, double pulsesPerDegree) {
+        public static TalonController talonController(int deviceNumber, double pulsesPerDegree,
+                double analogTurnsOverVoltageRange) {
             CANTalon talon = new CANTalon(deviceNumber);
-            return new HardwareTalonController(talon, pulsesPerDegree);
+            HardwareTalonController c = new HardwareTalonController(talon, pulsesPerDegree, analogTurnsOverVoltageRange);
+            return c;
         }
     }
 

--- a/strongback/src/org/strongback/hardware/HardwarePneumaticsModule.java
+++ b/strongback/src/org/strongback/hardware/HardwarePneumaticsModule.java
@@ -16,6 +16,7 @@
 
 package org.strongback.hardware;
 
+import org.strongback.annotation.ThreadSafe;
 import org.strongback.components.CurrentSensor;
 import org.strongback.components.PneumaticsModule;
 import org.strongback.components.Relay;
@@ -29,7 +30,8 @@ import edu.wpi.first.wpilibj.Compressor;
  *
  * @author Randall Hauch
  */
-public class HardwarePneumaticsModule implements PneumaticsModule {
+@ThreadSafe
+class HardwarePneumaticsModule implements PneumaticsModule {
 
     private final Compressor pcm;
     private final Relay closedLoop;

--- a/strongback/src/org/strongback/hardware/HardwareTalonController.java
+++ b/strongback/src/org/strongback/hardware/HardwareTalonController.java
@@ -87,14 +87,9 @@ class HardwareTalonController extends HardwareTalonSRX implements TalonControlle
     private volatile int currentProfile = 0;
     private final Set<Integer> profiles = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-    HardwareTalonController(CANTalon talon, double pulsesPerDegree) {
-        super(talon, pulsesPerDegree);
+    HardwareTalonController(CANTalon talon, double pulsesPerDegree, double analogTurnsOverVoltageRange) {
+        super(talon, pulsesPerDegree, analogTurnsOverVoltageRange);
         profiles.add(currentProfile);
-    }
-
-    @Override
-    public int getDeviceID() {
-        return talon.getDeviceID();
     }
 
     @Override
@@ -177,7 +172,7 @@ class HardwareTalonController extends HardwareTalonSRX implements TalonControlle
 
     @Override
     public TalonController setFeedbackDevice(FeedbackDevice device) {
-        talon.setFeedbackDevice(edu.wpi.first.wpilibj.CANTalon.FeedbackDevice.valueOf(device.value()));
+        super.setFeedbackDevice(device);
         return this;
     }
 
@@ -195,7 +190,7 @@ class HardwareTalonController extends HardwareTalonSRX implements TalonControlle
 
     @Override
     public TalonController reverseSensor(boolean flip) {
-        talon.reverseSensor(flip);
+        super.reverseSensor(flip);
         return this;
     }
 
@@ -310,7 +305,7 @@ class HardwareTalonController extends HardwareTalonSRX implements TalonControlle
 
     @Override
     public TalonController setVoltageRampRate(double rampRate) {
-        talon.setVoltageRampRate(rampRate);
+        super.setVoltageRampRate(rampRate);
         return this;
     }
 

--- a/strongback/src/org/strongback/hardware/HardwareTalonController.java
+++ b/strongback/src/org/strongback/hardware/HardwareTalonController.java
@@ -1,0 +1,334 @@
+/*
+ * Strongback
+ * Copyright 2015, Strongback and individual contributors by the @authors tag.
+ * See the COPYRIGHT.txt in the distribution for a full listing of individual
+ * contributors.
+ *
+ * Licensed under the MIT License; you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.strongback.hardware;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.strongback.Executable;
+import org.strongback.annotation.ThreadSafe;
+import org.strongback.control.Controller;
+import org.strongback.control.PIDController;
+import org.strongback.control.TalonController;
+
+import edu.wpi.first.wpilibj.CANTalon;
+
+/**
+ * A hardware-based Talon SRX PID controller.
+ */
+@ThreadSafe
+class HardwareTalonController extends HardwareTalonSRX implements TalonController {
+
+    private static final Executable NO_OP = (clock) -> {
+    };
+
+    private static final class Gains implements TalonController.Gains {
+        private final double p;
+        private final double i;
+        private final double d;
+        private final double feedForward;
+        private final double iZone;
+        private final double closedLoopRampRate;
+
+        protected Gains(double p, double i, double d, double feedForward, double iZone, double closeLoopRampRate) {
+            this.p = p;
+            this.i = i;
+            this.d = d;
+            this.feedForward = feedForward;
+            this.iZone = iZone;
+            this.closedLoopRampRate = closeLoopRampRate;
+        };
+
+        @Override
+        public double getP() {
+            return p;
+        }
+
+        @Override
+        public double getI() {
+            return i;
+        }
+
+        @Override
+        public double getD() {
+            return d;
+        }
+
+        @Override
+        public double getFeedForward() {
+            return feedForward;
+        }
+        @Override
+        public double getIzone() {
+            return iZone;
+        }
+        @Override
+        public double getCloseLoopRampRate() {
+            return closedLoopRampRate;
+        }
+    }
+
+    private double tolerance;
+    private volatile int currentProfile = 0;
+    private final Set<Integer> profiles = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    HardwareTalonController(CANTalon talon, double pulsesPerDegree) {
+        super(talon, pulsesPerDegree);
+        profiles.add(currentProfile);
+    }
+
+    @Override
+    public int getDeviceID() {
+        return talon.getDeviceID();
+    }
+
+    @Override
+    public Controller disable() {
+        talon.disable();
+        return this;
+    }
+
+    @Override
+    public Controller enable() {
+        talon.enableControl();
+        return this;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return talon.isControlEnabled();
+    }
+
+    @Override
+    public double getValue() {
+        return talon.get();
+    }
+
+    @Override
+    public double getTarget() {
+        return talon.getSetpoint();
+    }
+
+    @Override
+    public Controller withTarget(double target) {
+        talon.set(target);
+        return this;
+    }
+
+    @Override
+    public double getTolerance() {
+        return this.tolerance;
+    }
+
+    @Override
+    public Controller withTolerance(double tolerance) {
+        this.tolerance = tolerance;
+        return this;
+    }
+
+    @Override
+    public boolean computeOutput() {
+        // The Talon SRX is always computing output, so we don't have to do anything except
+        // return whether we're within tolerance ...
+        return isWithinTolerance();
+    }
+
+    @Override
+    public Controller reset() {
+        talon.ClearIaccum();
+        return this;
+    }
+
+    @Override
+    public Executable executable() {
+        return NO_OP;
+    }
+
+    @Override
+    public boolean hasExecutable() {
+        return false;
+    }
+
+    @Override
+    public ControlMode getControlMode() {
+        return ControlMode.valueOf(talon.getControlMode().value);
+    }
+
+    @Override
+    public TalonController setControlMode(ControlMode mode) {
+        talon.changeControlMode(edu.wpi.first.wpilibj.CANTalon.ControlMode.valueOf(mode.value()));
+        return this;
+    }
+
+    @Override
+    public TalonController setFeedbackDevice(FeedbackDevice device) {
+        talon.setFeedbackDevice(edu.wpi.first.wpilibj.CANTalon.FeedbackDevice.valueOf(device.value()));
+        return this;
+    }
+
+    @Override
+    public TalonController setStatusFrameRate(StatusFrameRate frameRate, int periodMillis) {
+        talon.setStatusFrameRateMs(edu.wpi.first.wpilibj.CANTalon.StatusFrameRate.valueOf(frameRate.value()), periodMillis);
+        return this;
+    }
+
+    @Override
+    public TalonController reverseOutput(boolean flip) {
+        talon.reverseOutput(flip);
+        return this;
+    }
+
+    @Override
+    public TalonController reverseSensor(boolean flip) {
+        talon.reverseSensor(flip);
+        return this;
+    }
+
+    @Override
+    public TalonController setForwardSoftLimit(int forwardLimit) {
+        super.setForwardSoftLimit(forwardLimit);
+        return this;
+    }
+
+    @Override
+    public TalonController enableForwardSoftLimit(boolean enable) {
+        super.enableForwardSoftLimit(enable);
+        return this;
+    }
+
+    @Override
+    public TalonController setReverseSoftLimit(int reverseLimit) {
+        super.setReverseSoftLimit(reverseLimit);
+        return this;
+    }
+
+    @Override
+    public TalonController enableReverseSoftLimit(boolean enable) {
+        super.enableReverseSoftLimit(enable);
+        return this;
+    }
+
+    @Override
+    public TalonController enableLimitSwitch(boolean forward, boolean reverse) {
+        super.enableLimitSwitch(forward, reverse);
+        return this;
+    }
+
+    @Override
+    public TalonController enableBrakeMode(boolean brake) {
+        super.enableBrakeMode(brake);
+        return this;
+    }
+
+    @Override
+    public TalonController setForwardLimitSwitchNormallyOpen(boolean normallyOpen) {
+        super.setForwardLimitSwitchNormallyOpen(normallyOpen);
+        return this;
+    }
+
+    @Override
+    public TalonController setReverseLimitSwitchNormallyOpen(boolean normallyOpen) {
+        super.setReverseLimitSwitchNormallyOpen(normallyOpen);
+        return this;
+    }
+
+    @Override
+    public TalonController withGains(double p, double i, double d) {
+        talon.setPID(p, i, d);
+        return this;
+    }
+
+    @Override
+    public TalonController withGains(double p, double i, double d, double feedForward) {
+        talon.setPID(p, i, d);
+        talon.setF(feedForward);
+        return this;
+    }
+
+    @Override
+    public TalonController withGains(double p, double i, double d, double feedForward, int izone, double closeLoopRampRate) {
+        talon.setPID(p, i, d);
+        talon.setF(feedForward);
+        talon.setIZone(izone);
+        talon.setCloseLoopRampRate(closeLoopRampRate);
+        return this;
+    }
+
+    @Override
+    public TalonController withProfile(int profile, double p, double i, double d) {
+        return withProfile(profile,p,i,d,0.0,0,0.0);
+    }
+
+    @Override
+    public TalonController withProfile(int profile, double p, double i, double d, double feedForward) {
+        return withProfile(profile,p,i,d,feedForward,0,0.0);
+    }
+
+    @Override
+    public TalonController withProfile(int profile, double p, double i, double d, double feedForward, int izone, double closeLoopRampRate) {
+        talon.setPID(p, i, d, feedForward, izone, closeLoopRampRate, profile);
+        return this;
+    }
+
+    @Override
+    public PIDController useProfile(int profile) {
+        talon.setProfile(profile);
+        this.currentProfile = profile;
+        this.profiles.add(profile);
+        return this;
+    }
+
+    @Override
+    public int getCurrentProfile() {
+        return currentProfile;
+    }
+
+    @Override
+    public Set<Integer> getProfiles() {
+        return Collections.unmodifiableSet(profiles);
+    }
+
+    @Override
+    public TalonController.Gains getGainsForCurrentProfile() {
+        return new Gains(talon.getP(),talon.getI(), talon.getD(), talon.getF(), talon.getIZone(), talon.getCloseLoopRampRate());
+    }
+
+    @Override
+    public TalonController setVoltageRampRate(double rampRate) {
+        talon.setVoltageRampRate(rampRate);
+        return this;
+    }
+
+    @Override
+    public TalonController clearStickyFaults() {
+        super.clearStickyFaults();
+        return this;
+    }
+
+    @Override
+    public TalonController setSafetyEnabled(boolean enabled) {
+        super.setSafetyEnabled(enabled);
+        return this;
+    }
+
+    @Override
+    public TalonController setExpiration(double timeout) {
+        super.setExpiration(timeout);
+        return this;
+    }
+}

--- a/strongback/src/org/strongback/hardware/HardwareTalonController.java
+++ b/strongback/src/org/strongback/hardware/HardwareTalonController.java
@@ -116,12 +116,13 @@ class HardwareTalonController extends HardwareTalonSRX implements TalonControlle
 
     @Override
     public double getTarget() {
-        return talon.getSetpoint();
+        double targetPosition = talon.getSetpoint();
+        return this.selectedInput.angleInDegreesFromRawPosition(targetPosition);
     }
 
     @Override
-    public Controller withTarget(double target) {
-        talon.set(target);
+    public TalonController withTarget(double angleInDegrees) {
+        talon.set(this.selectedInput.rawPositionForAngleInDegrees(angleInDegrees));
         return this;
     }
 
@@ -131,7 +132,7 @@ class HardwareTalonController extends HardwareTalonSRX implements TalonControlle
     }
 
     @Override
-    public Controller withTolerance(double tolerance) {
+    public TalonController withTolerance(double tolerance) {
         this.tolerance = tolerance;
         return this;
     }

--- a/strongback/src/org/strongback/hardware/HardwareTalonSRX.java
+++ b/strongback/src/org/strongback/hardware/HardwareTalonSRX.java
@@ -18,6 +18,7 @@ package org.strongback.hardware;
 
 import java.util.function.DoubleSupplier;
 
+import org.strongback.Strongback;
 import org.strongback.annotation.Immutable;
 import org.strongback.components.CurrentSensor;
 import org.strongback.components.Gyroscope;
@@ -280,10 +281,20 @@ class HardwareTalonSRX implements TalonSRX {
         switch(device) {
             case ANALOG_POTENTIOMETER:
             case ANALOG_ENCODER:
-                selectedInput = selectedAnalogInput;
+                if ( selectedAnalogInput != null ) {
+                    selectedInput = selectedAnalogInput;
+                } else {
+                    Strongback.logger(getClass()).error("Unable to use the analog input for feedback, since the Talon SRX (device " + getDeviceID() + ") was not instantiated with an analog input. Check how this device was created using Strongback's Hardware class.");
+                    selectedInput = NO_OP_GYRO;
+                }
                 break;
             case QUADRATURE_ENCODER:
-                selectedInput = selectedEncoderInput;
+                if ( selectedEncoderInput != null ) {
+                    selectedInput = selectedEncoderInput;
+                } else {
+                    Strongback.logger(getClass()).error("Unable to use the quadrature encoder input for feedback, since the Talon SRX (device " + getDeviceID() + ") was not instantiated with an encoder input. Check how this device was created using Strongback's Hardware class.");
+                    selectedInput = NO_OP_GYRO;
+                }
                 break;
             case ENCODER_FALLING:
             case ENCODER_RISING:
@@ -297,16 +308,16 @@ class HardwareTalonSRX implements TalonSRX {
     @Override
     public TalonSRX setStatusFrameRate(StatusFrameRate frameRate, int periodMillis) {
         talon.setStatusFrameRateMs(edu.wpi.first.wpilibj.CANTalon.StatusFrameRate.valueOf(frameRate.value()), periodMillis);
-        double rateInSeconds = periodMillis / 1000.0;
+        double periodInSeconds = periodMillis / 1000.0;
         switch(frameRate) {
             case FEEDBACK:
-                feedbackRateInSeconds = rateInSeconds;
+                feedbackRateInSeconds = periodInSeconds;
                 break;
             case QUADRATURE_ENCODER:
-                quadratureRateInSeconds = rateInSeconds;
+                quadratureRateInSeconds = periodInSeconds;
                 break;
             case ANALOG_TEMPERATURE_BATTERY_VOLTAGE:
-                analogRateInSeconds = rateInSeconds;
+                analogRateInSeconds = periodInSeconds;
                 break;
             case GENERAL:
                 // do nothing

--- a/strongback/src/org/strongback/hardware/HardwareTalonSRX.java
+++ b/strongback/src/org/strongback/hardware/HardwareTalonSRX.java
@@ -40,7 +40,12 @@ import edu.wpi.first.wpilibj.CANTalon.ControlMode;
 @Immutable
 class HardwareTalonSRX implements TalonSRX {
 
-    protected static final Gyroscope NO_OP_GYRO = new Gyroscope() {
+    protected static interface InputSensor extends Gyroscope {
+        public double rawPositionForAngleInDegrees( double angle );
+        public double angleInDegreesFromRawPosition( double position );
+    }
+
+    protected static final InputSensor NO_OP_SENSOR = new InputSensor() {
 
         @Override
         public double getAngle() {
@@ -52,75 +57,146 @@ class HardwareTalonSRX implements TalonSRX {
             return 0;
         }
         @Override
-        public Gyroscope zero() {
-            // do nothing
-            return this;
+        public InputSensor zero() {
+            return this; // do nothing
+        }
+
+        @Override
+        public double rawPositionForAngleInDegrees(double angleInDegrees) {
+            return 0.0;
+        }
+
+        @Override
+        public double angleInDegreesFromRawPosition(double position) {
+            return 0.0;
         }
     };
 
-    protected static Gyroscope encoderGyroscope(DoubleSupplier positionInPulses, DoubleSupplier velocityInPulsesPerCycle,
-            double pulsesPerDegree, DoubleSupplier cyclesPeriodInSeconds) {
-        if ( pulsesPerDegree <= 0.0000001d && pulsesPerDegree >= 0.0000001d ) return null;
-        return new Gyroscope() {
-            private double zero = 0.0;
+    protected static final class EncoderInputSensor implements InputSensor {
+        private double zero = 0.0;
+        private final DoubleSupplier positionInEdges;
+        private final DoubleSupplier velocityInEdgesPerCycle;
+        private final DoubleSupplier cyclePeriodInSeconds;
+        private final double pulsesPerDegree;
+        private final double edgesPerPulse;
 
-            @Override
-            public double getAngle() {
-                // Units: (pulses) x (degrees/pulse) = degrees
-                return (positionInPulses.getAsDouble() - zero) / pulsesPerDegree;
-            }
+        protected EncoderInputSensor( DoubleSupplier positionInEdges, DoubleSupplier velocityInEdgesPerCycle,
+            double pulsesPerDegree, int edgesPerPulse, DoubleSupplier cyclesPeriodInSeconds ) {
+            this.positionInEdges = positionInEdges;
+            this.velocityInEdgesPerCycle = velocityInEdgesPerCycle;
+            this.cyclePeriodInSeconds = cyclesPeriodInSeconds;
+            this.pulsesPerDegree = pulsesPerDegree;
+            this.edgesPerPulse = edgesPerPulse;
+        }
 
-            @Override
-            public double getRate() {
-                // Units: (pulses/cycle) x (degrees/pulse) x (cycles/second) = (degrees/second)
-                return velocityInPulsesPerCycle.getAsDouble() / pulsesPerDegree / cyclesPeriodInSeconds.getAsDouble();
-            }
+        @Override
+        public double rawPositionForAngleInDegrees(double angle) {
+            // Units: (degrees) x (pulses/degrees) * (edges/pulses) = (edges)
+            double relativeInput = angle * pulsesPerDegree * edgesPerPulse;
+            return relativeInput + zero;
+        }
 
-            @Override
-            public Gyroscope zero() {
-                zero = positionInPulses.getAsDouble();
-                return this;
-            }
-        };
+        @Override
+        public double angleInDegreesFromRawPosition(double position) {
+            // Units: (edges) x (pulse/edges) x (degrees/pulse) = degrees
+            return (position - zero) / edgesPerPulse / pulsesPerDegree;
+        }
+
+        @Override
+        public double getAngle() {
+            return angleInDegreesFromRawPosition(positionInEdges.getAsDouble());
+        }
+
+        @Override
+        public double getRate() {
+            // Units: (edges/cycle) * (pulses/edge) x (degrees/pulse) x (cycles/second) = (degrees/second)
+            return velocityInEdgesPerCycle.getAsDouble() / edgesPerPulse / pulsesPerDegree / cyclePeriodInSeconds.getAsDouble();
+        }
+
+        @Override
+        public Gyroscope zero() {
+            zero = positionInEdges.getAsDouble();
+            return this;
+        }
     }
 
-    protected static Gyroscope analogGyroscope(DoubleSupplier analogPosition, DoubleSupplier changeInVoltsPerCycle,
+    protected static final class AnalogInputSensor implements InputSensor {
+        private double zero = 0.0;
+        private final DoubleSupplier analogPosition;
+        private final DoubleSupplier changeInVoltsPerCycle;
+        private final DoubleSupplier cyclePeriodInSeconds;
+        private final double analogRange;
+        private final double analogTurnsPerVolt;
+        private final double voltageRange;
+
+        protected AnalogInputSensor( DoubleSupplier analogPosition, DoubleSupplier changeInVoltsPerCycle,
+                double analogRange, double analogTurnsPerVolt, double voltageRange, DoubleSupplier cyclePeriodInSeconds ) {
+            this.analogPosition = analogPosition;
+            this.changeInVoltsPerCycle = changeInVoltsPerCycle;
+            this.cyclePeriodInSeconds = cyclePeriodInSeconds;
+            this.analogRange = analogRange;
+            this.analogTurnsPerVolt = analogTurnsPerVolt;
+            this.voltageRange = voltageRange;
+        }
+
+        @Override
+        public double rawPositionForAngleInDegrees(double angle) {
+            // Units: (0-1023) / 1023 x (turns/volt) x (volts) x (degrees/turn) = degrees
+            // Units: (degrees) x (turns/degrees) x (1/volts) x (volts/turn) * 1023  = (0-1023)
+            double relativeInput = angle / 360.0 / voltageRange / analogTurnsPerVolt * analogRange;
+            return relativeInput + zero;
+        }
+
+        @Override
+        public double angleInDegreesFromRawPosition(double position) {
+            // Units: (0-1023) / 1023 x (turns/volt) x (volts) x (degrees/turn) = degrees
+            return (position - zero) / analogRange * analogTurnsPerVolt * voltageRange * 360.0;
+        }
+        @Override
+        public double getAngle() {
+            return angleInDegreesFromRawPosition(analogPosition.getAsDouble());
+        }
+
+        @Override
+        public double getRate() {
+            // Units: (0-1023)/cycle / 1023 x (turns/volt) x (volts) x (degrees/turn) x (cycles/second) = (degrees/second)
+            return changeInVoltsPerCycle.getAsDouble() / analogRange * analogTurnsPerVolt * voltageRange * 360.0
+                    / cyclePeriodInSeconds.getAsDouble();
+        }
+
+        @Override
+        public Gyroscope zero() {
+            zero = analogPosition.getAsDouble();
+            return this;
+        }
+    }
+
+    protected static EncoderInputSensor encoderInput(DoubleSupplier positionInPulses, DoubleSupplier velocityInPulsesPerCycle,
+            double pulsesPerDegree, int risesPerPulse, DoubleSupplier cyclePeriodInSeconds) {
+        if ( pulsesPerDegree <= 0.0000001d && pulsesPerDegree >= 0.0000001d ) return null;
+        return new EncoderInputSensor(positionInPulses, velocityInPulsesPerCycle, pulsesPerDegree, risesPerPulse, cyclePeriodInSeconds);
+    }
+
+    protected static AnalogInputSensor analogInput(DoubleSupplier analogPosition, DoubleSupplier changeInVoltsPerCycle,
             double analogRange, double analogTurnsPerVolt, double voltageRange, DoubleSupplier cyclesPeriodInSeconds) {
         if ( analogTurnsPerVolt <= 0.0000001d && analogTurnsPerVolt >= 0.0000001d ) return null;
-        return new Gyroscope() {
-            private double zero = 0.0;
-
-            @Override
-            public double getAngle() {
-                // Units: (0-1023) / 1023 x (turns/volt) x (volts) x (degrees/turn) = degrees
-                return (analogPosition.getAsDouble() - zero) / analogRange * analogTurnsPerVolt * voltageRange * 360.0;
-            }
-
-            @Override
-            public double getRate() {
-                // Units: (0-1023)/cycle / 1023 x (turns/volt) x (volts) x (degrees/turn) x (cycles/second) = (degrees/second)
-                return changeInVoltsPerCycle.getAsDouble() / analogRange * analogTurnsPerVolt * voltageRange * 360.0
-                        / cyclesPeriodInSeconds.getAsDouble();
-            }
-
-            @Override
-            public Gyroscope zero() {
-                zero = analogPosition.getAsDouble();
-                return this;
-            }
-        };
+        return new AnalogInputSensor(analogPosition, changeInVoltsPerCycle, analogRange, analogTurnsPerVolt, voltageRange, cyclesPeriodInSeconds);
     }
 
     private static final double DEFAULT_ANALOG_RATE = 0.100;
     private static final double DEFAULT_QUADRATURE_RATE = 0.100;
     private static final double DEFAULT_FEEDBACK_RATE = 0.020;
 
+    private static final int RISES_PER_PULSE = 4; // 4x mode
+    private static final double MAX_ANALOG_VOLTAGE = 3.3; // 0-3.3V
+    private static final double MAX_ANALOG_RANGE = 1023; // 10 bits non-continuous
+
     protected final CANTalon talon;
-    protected final Gyroscope encoderInput;
-    protected final Gyroscope analogInput;
-    protected final Gyroscope selectedEncoderInput;
-    protected final Gyroscope selectedAnalogInput;
-    protected volatile Gyroscope selectedInput = NO_OP_GYRO;
+    protected final InputSensor encoderInput;
+    protected final InputSensor analogInput;
+    protected final InputSensor selectedEncoderInput;
+    protected final InputSensor selectedAnalogInput;
+    protected volatile InputSensor selectedInput = NO_OP_SENSOR;
     protected volatile double quadratureRateInSeconds = DEFAULT_QUADRATURE_RATE;
     protected volatile double analogRateInSeconds = DEFAULT_ANALOG_RATE;
     protected volatile double feedbackRateInSeconds = DEFAULT_FEEDBACK_RATE;
@@ -142,25 +218,27 @@ class HardwareTalonSRX implements TalonSRX {
         this.outputVoltage = talon::getOutputVoltage;
         this.busVoltage = talon::getBusVoltage;
         this.temperature = talon::getTemp;
-        this.encoderInput = encoderGyroscope(talon::getEncPosition,
+        this.encoderInput = encoderInput(talon::getEncPosition,
                                              talon::getEncVelocity,
                                              pulsesPerDegree,
+                                             RISES_PER_PULSE,
                                              () -> quadratureRateInSeconds);
-        this.analogInput = analogGyroscope(talon::getAnalogInPosition,
+        this.analogInput = analogInput(talon::getAnalogInPosition,
                                            talon::getAnalogInVelocity,
-                                           1023,
-                                           analogTurnsOverVoltageRange / 3.3,
-                                           3.3,
+                                           MAX_ANALOG_RANGE,
+                                           analogTurnsOverVoltageRange / MAX_ANALOG_VOLTAGE,
+                                           MAX_ANALOG_VOLTAGE,
                                            () -> analogRateInSeconds);
-        this.selectedEncoderInput = encoderGyroscope(talon::getPosition,
+        this.selectedEncoderInput = encoderInput(talon::getPosition,
                                              talon::getSpeed,
                                              pulsesPerDegree,
+                                             RISES_PER_PULSE,
                                              () -> feedbackRateInSeconds);
-        this.selectedAnalogInput = analogGyroscope(talon::getPosition,
+        this.selectedAnalogInput = analogInput(talon::getPosition,
                                            talon::getSpeed,
-                                           1023,
-                                           analogTurnsOverVoltageRange / 3.3,
-                                           3.3,
+                                           MAX_ANALOG_RANGE,
+                                           analogTurnsOverVoltageRange / MAX_ANALOG_VOLTAGE,
+                                           MAX_ANALOG_VOLTAGE,
                                            () -> feedbackRateInSeconds);
         this.instantaneousFaults = new Faults() {
             @Override
@@ -285,21 +363,21 @@ class HardwareTalonSRX implements TalonSRX {
                     selectedInput = selectedAnalogInput;
                 } else {
                     Strongback.logger(getClass()).error("Unable to use the analog input for feedback, since the Talon SRX (device " + getDeviceID() + ") was not instantiated with an analog input. Check how this device was created using Strongback's Hardware class.");
-                    selectedInput = NO_OP_GYRO;
+                    selectedInput = NO_OP_SENSOR;
                 }
                 break;
             case QUADRATURE_ENCODER:
+            case ENCODER_RISING:
                 if ( selectedEncoderInput != null ) {
                     selectedInput = selectedEncoderInput;
                 } else {
                     Strongback.logger(getClass()).error("Unable to use the quadrature encoder input for feedback, since the Talon SRX (device " + getDeviceID() + ") was not instantiated with an encoder input. Check how this device was created using Strongback's Hardware class.");
-                    selectedInput = NO_OP_GYRO;
+                    selectedInput = NO_OP_SENSOR;
                 }
                 break;
             case ENCODER_FALLING:
-            case ENCODER_RISING:
                 // for 2015 the Talon SRX firmware did not support the falling or rising mode ...
-                selectedInput = NO_OP_GYRO;
+                selectedInput = NO_OP_SENSOR;
                 break;
         }
         return this;
@@ -320,7 +398,7 @@ class HardwareTalonSRX implements TalonSRX {
                 analogRateInSeconds = periodInSeconds;
                 break;
             case GENERAL:
-                // do nothing
+                // nothing to set, since our code doesn't use the "general" frames
                 break;
         }
         return this;


### PR DESCRIPTION
**Not yet ready for merging**

Slightly modified the existing `Controller` interface (which is implemented for software-based PID control with `PIDController`) and added a `TalonController` that is able to configure, manage, monitor, and use PID control on the Talon SRX motor controller. The `TalonController` interface is quite large and complex, since it attempts to expose all of the `wpilibj.CANTalon` functionality without exposing any of the `CANTalon` class.

The new `TalonController` works with the existing `ControlledCommand` class that takes a `Controller` implementation.

A `MockController` class was also implemented to allow testing of components that use a `Controller` implementation, where the tests can manually set the error and verify the component responds correctly. This might be difficult for components that directly use `PIDController` or `TalonController`, but where possible the components should limit their use to `Controller`, which does allow changing the setpoint, tolerance, and enabling/disabling the controller. (This will not always be possible, since components may need to set or change PID gains.)

Closes #40 
