### PR TITLE
Corrected the jar task in the build.xml that Strongback uses to build projects

### DIFF
--- a/ant/strongback/build.xml
+++ b/ant/strongback/build.xml
@@ -55,6 +55,13 @@
 		<mkdir dir="${dist.dir}" />
 		<mkdir dir="${build.jars}" />
 
+        <echo>Copying jars from ${strongback.classpath} to ${build.jars}.</echo>
+        <copy todir="${build.jars}" flatten="true">
+            <path>
+                <pathelement path="${strongback.classpath}"/>
+            </path>
+        </copy>
+
 		<jar destfile="${dist.jar}" update="false">
 			<manifest>
 				<attribute name="Main-Class" value="edu.wpi.first.wpilibj.RobotBase"/>
@@ -68,14 +75,6 @@
 				<include name="**/*.jar" />
 			</zipgroupfileset>
 		</jar>
-
-		<echo>Copying jars from ${strongback.classpath} to ${build.jars}.</echo>
-		<copy todir="${build.jars}" flatten="true">
-			<file file="${dist.jar}"/>
-			<path>
-				<pathelement path="${strongback.classpath}"/>
-			</path>
-		</copy>
 	</target>
 
     <!-- Check if there are any JUnit Tests -->

--- a/ant/strongback/build.xml
+++ b/ant/strongback/build.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="Strongback Deployment">
-    <property name="resources.dir" value="resources"/>
-    <property name="test.resources.dir" value="testresources"/>
-    <property name="test.source.dir" value="testsrc"/>
-	<property name="test.output.dir" value="tests"/>
-	<property name="test.report.dir" value="${test.output.dir}/classes"/>
-	<property name="test.target.dir" value="${test.output.dir}/classes"/>
-    <property file="${user.home}/wpilib/wpilib.properties"/>
-    <property file="${user.home}/wpilib/java/${version}/ant/build.properties"/>
-    <property file="${user.home}/strongback/java/ant/build.properties"/>
+    <property name="resources.dir" value="resources" />
+    <property name="test.resources.dir" value="testresources" />
+    <property name="test.source.dir" value="testsrc" />
+    <property name="test.output.dir" value="tests" />
+    <property name="test.report.dir" value="${test.output.dir}/classes" />
+    <property name="test.target.dir" value="${test.output.dir}/classes" />
+    <property file="${user.home}/wpilib/wpilib.properties" />
+    <property file="${user.home}/wpilib/java/${version}/ant/build.properties" />
+    <property file="${user.home}/strongback/java/ant/build.properties" />
 
-	<import file="${wpilib.ant.dir}/build.xml"/>
+    <import file="${wpilib.ant.dir}/build.xml" />
 	
     <!-- Define the classpaths -->
     <path id="compile.classpath">
-        <fileset dir="${strongback.home}/java/lib" includes="**/*.jar" excludes="**/*-sources.jar"/>
-        <fileset dir="${user.home}/wpilib/java/${version}/lib" includes="**/*.jar" excludes="**/*-sources.jar"/>
+        <fileset dir="${strongback.home}/java/lib" includes="**/*.jar" excludes="**/*-sources.jar" />
+        <fileset dir="${user.home}/wpilib/java/${version}/lib" includes="**/*.jar" excludes="**/*-sources.jar" />
         <pathelement path="${classpath}" />
     </path>
 
     <!-- Define a classpath for unit testing -->
     <path id="junit.classpath">
-        <fileset dir="${strongback.home}/java/lib" includes="**/*.jar" excludes="**/*-sources.jar"/>
-        <fileset dir="${strongback.home}/java/lib-tests" includes="**/*.jar" excludes="**/*-sources.jar"/>
+        <fileset dir="${strongback.home}/java/lib" includes="**/*.jar" excludes="**/*-sources.jar" />
+        <fileset dir="${strongback.home}/java/lib-tests" includes="**/*.jar" excludes="**/*-sources.jar" />
         <pathelement location="${build.dir}" />
         <pathelement path="${classpath}" />
     </path>
@@ -34,53 +34,53 @@
 	    
     <!-- Deletes the directories used by the tests-->
     <target name="clean" depends="clean-tests" description="Clean up all generated files">
-        <ant antfile="${wpilib.ant.dir}/build.xml" target="clean"/>
+        <ant antfile="${wpilib.ant.dir}/build.xml" target="clean" />
     </target>
 
-	<target name="compile" description="Compile the source code.">
-	    <mkdir dir="${build.dir}"/>
-	    <javac srcdir="${src.dir}" destdir="${build.dir}" includeantruntime="false">
-            <classpath refid="compile.classpath"/>
-		</javac>
+    <target name="compile" description="Compile the source code.">
+        <mkdir dir="${build.dir}" />
+        <javac srcdir="${src.dir}" destdir="${build.dir}" includeantruntime="false">
+            <classpath refid="compile.classpath" />
+        </javac>
         <copy todir="${build.dir}">
             <fileset dir="${src.dir}" includes="**/*.xml,**/*.properties,**/*.txt,**/*.ico" />
         </copy>
         <copy todir="${build.dir}" failonerror="false" quiet="true">
-            <fileset dir="${resources.dir}"/>
+            <fileset dir="${resources.dir}" />
         </copy>
-	</target>
+    </target>
 
-	<target name="jar" depends="compile">
-		<echo>Making jar ${dist.jar}.</echo>
-		<mkdir dir="${dist.dir}" />
-		<mkdir dir="${build.jars}" />
+    <target name="jar" depends="compile">
+        <echo>Making jar ${dist.jar}.</echo>
+        <mkdir dir="${dist.dir}" />
+        <mkdir dir="${build.jars}" />
 
         <echo>Copying jars from ${strongback.classpath} to ${build.jars}.</echo>
         <copy todir="${build.jars}" flatten="true">
             <path>
-                <pathelement path="${strongback.classpath}"/>
+                <pathelement path="${strongback.classpath}" />
             </path>
         </copy>
 
-		<jar destfile="${dist.jar}" update="false">
-			<manifest>
-				<attribute name="Main-Class" value="edu.wpi.first.wpilibj.RobotBase"/>
-				<attribute name="Robot-Class" value="${robot.class}"/>
-				<attribute name="Class-Path" value="."/>
-			</manifest>
+        <jar destfile="${dist.jar}" update="false">
+            <manifest>
+                <attribute name="Main-Class" value="edu.wpi.first.wpilibj.RobotBase" />
+                <attribute name="Robot-Class" value="${robot.class}" />
+                <attribute name="Class-Path" value="." />
+            </manifest>
 
-			<fileset dir="${build.dir}" includes="**/*.class"/>
+            <fileset dir="${build.dir}" includes="**/*.class" />
 
-			<zipgroupfileset dir="${build.jars}">
-				<include name="**/*.jar" />
-			</zipgroupfileset>
-		</jar>
-	</target>
+            <zipgroupfileset dir="${build.jars}">
+                <include name="**/*.jar" />
+            </zipgroupfileset>
+        </jar>
+    </target>
 
     <!-- Check if there are any JUnit Tests -->
     <target name="if-tests">
         <condition property="tests-exists">
-            <available file="testsrc" type="dir"/>
+            <available file="testsrc" type="dir" />
         </condition>
     </target>
 
@@ -94,30 +94,30 @@
             <fileset dir="${test.source.dir}" includes="**/*.xml,**/*.properties,**/*.txt,**/*.ico" />
         </copy>
         <copy todir="${test.target.dir}" failonerror="false" quiet="true">
-            <fileset dir="${test.resources.dir}"/>
+            <fileset dir="${test.resources.dir}" />
         </copy>
     </target>
 
     <!-- Run the JUnit Tests -->
     <target name="test" depends="compile-tests, if-tests" if="tests-exists" description="Run the unit tests">
 	    <!-- Creates the directories used in the tests -->
-	    <mkdir dir="${test.target.dir}" />
-	    <mkdir dir="${test.report.dir}" />
-	    <echo>[run-tests] Running all unit tests...</echo>
-	    <junit printsummary="off" showOutput="false" fork="false" haltonfailure="no" failureproperty="test.failed" >
-	      <classpath refid="junit.classpath" />
-	      <classpath>
-	        <pathelement location="${test.target.dir}"/>
-	      </classpath>
-	      <formatter type="plain" usefile="false" /> <!-- to screen -->
-	      <batchtest todir="${test.report.dir}">
-	        <fileset dir="${test.source.dir}">
-	          <include name="**/*Test*.java" />
-	          <include name="**/Test*.java" />
-	          <exclude name="**/Abstract*.java" />
-	        </fileset>
-	      </batchtest>
-	    </junit>
+        <mkdir dir="${test.target.dir}" />
+        <mkdir dir="${test.report.dir}" />
+        <echo>[run-tests] Running all unit tests...</echo>
+        <junit printsummary="off" showOutput="false" fork="false" haltonfailure="no" failureproperty="test.failed">
+            <classpath refid="junit.classpath" />
+            <classpath>
+                <pathelement location="${test.target.dir}" />
+            </classpath>
+            <formatter type="plain" usefile="false" /> <!-- to screen -->
+            <batchtest todir="${test.report.dir}">
+                <fileset dir="${test.source.dir}">
+                    <include name="**/*Test*.java" />
+                    <include name="**/Test*.java" />
+                    <exclude name="**/Abstract*.java" />
+                </fileset>
+            </batchtest>
+        </junit>
         <fail message="Test failure detected, check test results." if="test.failed" />
     </target>
 


### PR DESCRIPTION
Per #48, the "jar" task in the `build.xml` deployed and used to build projects was incorrect, and this PR fixes it per the suggestion in #48.

Fixes #48
