### PR TITLE
Corrected the Windows problems when initializing Eclipse and creating new Eclipse projects (Issue 54)

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-strongback.version=1.1.0
+strongback.version=1.1.1
 #
 # The build will download a specific version of the WPILib given by the following URL
 # and install it into the 'libs/wpilib' folder. To use a different version of WPILib,

--- a/strongback-tools/src/org/strongback/tools/utils/FileUtils.java
+++ b/strongback-tools/src/org/strongback/tools/utils/FileUtils.java
@@ -17,26 +17,60 @@
 package org.strongback.tools.utils;
 
 import java.io.File;
-import java.security.InvalidParameterException;
+import java.util.function.Supplier;
 
 /**
  * Utility methods for working with files
+ *
  * @author Zach Anderson
  *
  */
 public class FileUtils {
     /**
-     * Convenience method that resolves a filepath if it starts with ~
+     * Convenience method that replaces the {@code ~} character at the beginning of the supplied string with the user's home
+     * directory.
+     *
+     * @param path the path to resolve
+     * @return the path with the {@code ~} replaced with the user's home directory
+     */
+    public static final String resolveHome(String path) {
+        return resolveHome(path, () -> System.getProperty("user.home"));
+    }
+
+    /**
+     * Convenience method that resolves a file path if it starts with {@code ~}.
+     *
+     * @param path the path to resolve
+     * @param userHomeSupplier the value to be used for the home directory path; may not be null
+     * @return the path with the {@code ~} replaced with the user's home directory
+     */
+    public static final String resolveHome(String path, Supplier<String> userHomeSupplier) {
+        if (path.length() == 0) return path;
+        if (path.charAt(0) == '~') {
+            path = userHomeSupplier.get() + path.substring(1);
+        }
+        return path;
+    }
+
+    /**
+     * Convenience method that resolves a file path if it starts with {@code ~}.
+     *
      * @param path the path to resolve
      * @return an absolute {@link File} representing that path
      */
     public static final File resolvePath(String path) {
-        if(path.length()==0) throw new InvalidParameterException();
-        
-        if(path.charAt(0) == '~')
-            path = System.getProperty("user.home") + path.substring(1);
-        
-        File file = new File(path).getAbsoluteFile();
-        return file;
+        return resolvePath(path,() -> System.getProperty("user.home"));
+    }
+
+    /**
+     * Convenience method that resolves a file path if it starts with {@code ~}.
+     *
+     * @param path the path to resolve
+     * @param userHomeSupplier the value to be used for the home directory path; may not be null
+     * @return an absolute {@link File} representing that path
+     */
+    public static final File resolvePath(String path, Supplier<String> userHomeSupplier) {
+        path = resolveHome(path, userHomeSupplier);
+        return new File(path).getAbsoluteFile();
     }
 }

--- a/strongback-tools/test/org/strongback/tools/utils/FileUtilsTest.java
+++ b/strongback-tools/test/org/strongback/tools/utils/FileUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Strongback
+ * Copyright 2015, Strongback and individual contributors by the @authors tag.
+ * See the COPYRIGHT.txt in the distribution for a full listing of individual
+ * contributors.
+ *
+ * Licensed under the MIT License; you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.strongback.tools.utils;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+
+/**
+ * @author Randall Hauch
+ *
+ */
+public class FileUtilsTest {
+
+    @Test
+    public void shouldResolveHomeWithWindowsPath() {
+        // We can use forward paths, because Java resolves forward and back slashes the same way ...
+        String actual = FileUtils.resolveHome("~/strongback", () -> "C:/Users/AnnieSmith");
+        assertThat(actual).isEqualTo("C:/Users/AnnieSmith/strongback");
+    }
+
+    @Test
+    public void shouldResolveHomeWithLinuxPath() {
+        String actual = FileUtils.resolveHome("~/strongback", () -> "/Users/AnnieSmith");
+        assertThat(actual).isEqualTo("/Users/AnnieSmith/strongback");
+    }
+
+}


### PR DESCRIPTION
The `new-project` tool manipulates quite a few paths and generates/updates files. On Windows, the backslashes in the paths were causing problems with `String.replaceAll`, even though the backslashes appeared only in the replacement strings. The fix turned out to be replacing the backslashes used in the replacement paths with forward slashes, which is okay since Java file and path resolution works fine with both (even in the files generated for Eclipse).

However, to get there I had to add a bunch of debug statements to track what was going on. I did first replicate the problem on a borrowed Windows installation, and the debug statements helped me figure out what was going on. I was able to verify that this PR fixes the problem on Windows and that the behavior or Linux and OS X remains correct.

I was also able to verify that the Eclipse preference file that Strongback is updating didn't appear to be changed when the problem was manifesting itself. Therefore, affected users shouldn't need to clean anything up prior to installing the next version of Strongback (1.1.1) and re-running the functionality.
