### PR TITLE
Correct Talon SRX limit switches

### DIFF
--- a/strongback/src/org/strongback/hardware/HardwareTalonSRX.java
+++ b/strongback/src/org/strongback/hardware/HardwareTalonSRX.java
@@ -212,8 +212,8 @@ class HardwareTalonSRX implements TalonSRX {
     HardwareTalonSRX(CANTalon talon, double pulsesPerDegree, double analogTurnsOverVoltageRange) {
         this.talon = talon;
 
-        this.forwardLimitSwitch = talon::isRevLimitSwitchClosed;
-        this.reverseLimitSwitch = talon::isFwdLimitSwitchClosed;
+        this.forwardLimitSwitch = talon::isFwdLimitSwitchClosed;
+        this.reverseLimitSwitch = talon::isRevLimitSwitchClosed;
         this.outputCurrent = talon::getOutputCurrent;
         this.outputVoltage = talon::getOutputVoltage;
         this.busVoltage = talon::getBusVoltage;


### PR DESCRIPTION
Corrects the `HardwareTalonSRX` limit switches, which were reversed as reported in #64. However, rather than fixing this now we will wait until after the season since anyone using this would have already corrected the problem and upgrading would break their code.

closes #64
