### PR TITLE
Issue 81: Fixed CommandGroup behavior inconsistency

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,3 +3,4 @@ Matthew Alonso
 Nathan Brown
 Randall Hauch
 Zach Anderson
+Rothanak So

--- a/strongback-tests/src/org/strongback/command/CommandGroupTest.java
+++ b/strongback-tests/src/org/strongback/command/CommandGroupTest.java
@@ -16,16 +16,16 @@
 
 package org.strongback.command;
 
-import static org.fest.assertions.Assertions.assertThat;
+import org.junit.Before;
+import org.junit.Test;
+import org.strongback.Logger;
 
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.strongback.Logger;
+import static org.fest.assertions.Assertions.assertThat;
 
 public class CommandGroupTest {
     private Scheduler scheduler;

--- a/strongback-tests/src/org/strongback/command/CommandGroupTest.java
+++ b/strongback-tests/src/org/strongback/command/CommandGroupTest.java
@@ -332,6 +332,51 @@ public class CommandGroupTest {
         }
     }
 
+    @Test
+    public void shouldExecuteComposedNamedCommandGroups() {
+        scheduler.submit(new OuterCommandGroup());
+
+        assertThat(list).isEmpty();
+
+        // First step should come from the OuterCommandGroup
+        scheduler.execute(0);
+        assertThat(list).isEqualTo(listOf("C0 init", "C0 exe", "C0 fin" ));
+        list.clear();
+
+        // Second step should come from NestedCommandGroup
+        scheduler.execute(0);
+        assertThat(list).isEqualTo(listOf("C1 init", "C1 exe", "C1 fin" ));
+        list.clear();
+
+        // Third step should come from NestedCommandGroup
+        scheduler.execute(0);
+        assertThat(list).isEqualTo(listOf("C2 init", "C2 exe", "C2 fin" ));
+        list.clear();
+
+        // Fourth step should resume the OuterCommandGroup sequence
+        scheduler.execute(0);
+        assertThat(list).isEqualTo(listOf("C3 init", "C3 exe", "C3 fin" ));
+        list.clear();
+
+        // Fifth step is empty, nothing executed
+        scheduler.execute(0);
+        assertThat(list).isEmpty();
+    }
+
+    private final class OuterCommandGroup extends CommandGroup {
+        @SuppressWarnings("synthetic-access")
+        public OuterCommandGroup() {
+            sequentially(c[0], new InnerNamedCommandGroup(), c[3]);
+        }
+
+        private final class InnerNamedCommandGroup extends CommandGroup {
+            @SuppressWarnings("synthetic-access")
+            public InnerNamedCommandGroup() {
+                sequentially(c[1], c[2]);
+            }
+        }
+    }
+
     private static final class TestCommand extends Command {
         private static int commandID = 0;
 

--- a/strongback/src/org/strongback/command/CommandGroup.java
+++ b/strongback/src/org/strongback/command/CommandGroup.java
@@ -151,19 +151,11 @@ public class CommandGroup extends Command {
     }
 
     Type getType() {
-        if (root != null) {
-            return root.type;
-        } else {
-            return type;
-        }
+        return root != null ? root.type : type;
     }
 
     Command[] getCommands() {
-        if (root != null) {
-            return root.getCommands();
-        } else {
-            return commands;
-        }
+        return root != null ? root.getCommands() : commands;
     }
 
     /**

--- a/strongback/src/org/strongback/command/CommandGroup.java
+++ b/strongback/src/org/strongback/command/CommandGroup.java
@@ -131,7 +131,7 @@ public class CommandGroup extends Command {
         SEQUENTIAL, PARRALLEL, FORK;
     }
 
-    private Command root;
+    private CommandGroup root;
     private final Command[] commands;
     private final Type type;
 
@@ -151,15 +151,19 @@ public class CommandGroup extends Command {
     }
 
     Type getType() {
-        return type;
+        if (root != null) {
+            return root.type;
+        } else {
+            return type;
+        }
     }
 
     Command[] getCommands() {
-        return commands;
-    }
-
-    Command getRoot() {
-        return root;
+        if (root != null) {
+            return root.getCommands();
+        } else {
+            return commands;
+        }
     }
 
     /**

--- a/strongback/src/org/strongback/command/Scheduler.java
+++ b/strongback/src/org/strongback/command/Scheduler.java
@@ -65,9 +65,6 @@ public class Scheduler implements Executable {
      */
     public void submit(Command command) {
         if (command != null) {
-            if (command instanceof CommandGroup) {
-                command = ((CommandGroup) command).getRoot();
-            }
             CommandRunner runner = buildRunner(command, null);
             commands.add(runner);
         }


### PR DESCRIPTION
Proposal to fix #81.

Subclassed CommandGroups are now indistinguishable from those created with the static helpers. This lets the Scheduler skip the `getRoot` step and forward the submitted command to the builder.

After playing around with this, I see why `root` is needed now. I decided the least invasive solution would be to remove `getRoot` (assuming it's not part of the public API) and keep the notion of root internal. Then the `getCommands` and `getType` methods would delegate to the root object if there is one.

Let me know what you think about this approach!
