### PR TITLE
Issue 84 - Simplify engine and executor

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-strongback.version=1.2.0
+strongback.version=1.2.0-Beta1
 #
 # The build will download a specific version of the WPILib given by the following URL
 # and install it into the 'libs/wpilib' folder. To use a different version of WPILib,

--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-strongback.version=1.1.7
+strongback.version=1.2.0
 #
 # The build will download a specific version of the WPILib given by the following URL
 # and install it into the 'libs/wpilib' folder. To use a different version of WPILib,

--- a/build.xml
+++ b/build.xml
@@ -88,7 +88,6 @@
 
             <doctitle><![CDATA[<h1>Strongback Java Library</h1>]]></doctitle>
             <bottom><![CDATA[<i>Copyright &#169; ${current.year} Strongback and individual contributors. All Rights Reserved.</i>]]></bottom>
-            <tag name="todo" scope="all" description="To do:"/>
             <group title="Strongback" packages="org.strongback"/>
             <group title="Components" packages="org.strongback.components*:org.strongback.hardware*"/>
             <group title="Drives" packages="org.strongback.drive"/>

--- a/strongback-tests/src/org/strongback/StrongbackTest.java
+++ b/strongback-tests/src/org/strongback/StrongbackTest.java
@@ -1,0 +1,89 @@
+/*
+ * Strongback
+ * Copyright 2015, Strongback and individual contributors by the @authors tag.
+ * See the COPYRIGHT.txt in the distribution for a full listing of individual
+ * contributors.
+ *
+ * Licensed under the MIT License; you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.strongback;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.strongback.Logger.Level;
+import org.strongback.components.Clock;
+
+/**
+ * Tests that check the functionality of the {@link Strongback.Engine}.
+ */
+public class StrongbackTest {
+
+    private static final SystemLogger LOGGER = new SystemLogger();
+
+    private Clock clock;
+    private Strongback.Engine engine;
+
+    @Before
+    public void beforeEach() {
+        LOGGER.enable(Level.INFO);
+        clock = Clock.system();
+        engine = new Strongback.Engine(clock, LOGGER);
+    }
+
+    @After
+    public void afterEach() {
+        try {
+            if (engine != null && engine.isRunning()) {
+                engine.stop();
+            }
+        } finally {
+            engine = null;
+        }
+    }
+
+    @Test
+    public void shouldNotBeRunningWhenCreated() {
+        assertThat(engine.isRunning()).isFalse();
+    }
+
+    @Test
+    public void shouldStartWithDefaultConfiguration() {
+        engine.logConfiguration();
+        assertThat(engine.isRunning()).isFalse();
+        assertThat(engine.start()).isTrue();
+        assertThat(engine.isRunning()).isTrue();
+    }
+
+    @Test
+    public void shouldAllowChangingExecutionPeriodWhenNotRunning() {
+        assertThat(engine.isRunning()).isFalse();
+        assertThat(engine.getExecutionPeriod()).isEqualTo(20);
+        engine.setExecutionPeriod(5);
+        assertThat(engine.getExecutionPeriod()).isEqualTo(5);
+        assertThat(engine.start()).isTrue();
+        engine.logConfiguration();
+    }
+
+    @Test
+    public void shouldNotAllowChangingExecutionPeriodWhenRunning() {
+        assertThat(engine.isRunning()).isFalse();
+        assertThat(engine.start()).isTrue();
+        assertThat(engine.getExecutionPeriod()).isEqualTo(20);
+        LOGGER.enable(Level.OFF);
+        assertThat(engine.setExecutionPeriod(5)).isFalse();
+        LOGGER.enable(Level.INFO);
+        assertThat(engine.getExecutionPeriod()).isEqualTo(20);
+    }
+
+}

--- a/strongback/src/org/strongback/Executor.java
+++ b/strongback/src/org/strongback/Executor.java
@@ -24,21 +24,45 @@ import org.strongback.annotation.ThreadSafe;
 @ThreadSafe
 public interface Executor {
 
+    public static enum Priority {
+        HIGH, MEDIUM, LOW;
+    }
+
     /**
-     * Register an {@link Executable} task to be called repeatedly.
+     * Register a high priority {@link Executable} task so that it is called repeatedly on Strongback's executor thread.
      *
-     * @param r the executable task
-     * @return true if the executable task was registered, or false if it was null or was already registered with this executor
+     * @param task the executable task
+     * @return {@code true} if the executable task was registered for the first time as a high priority, or {@code false} if
+     *         {@code task} was null or was already registered with this executor at high priority
+     * @deprecated Use {@link #register(Executable, Priority)} instead
      */
-    public boolean register(Executable r);
+    @Deprecated
+    default boolean register(Executable task) {
+        return register(task, Priority.HIGH);
+    }
+
+    /**
+     * Register an {@link Executable} task with the given priority so that it is called repeatedly on Strongback's executor
+     * thread. If the given task is already registered with a different priority, this method reassigns it to the desired
+     * priority; if the given task is already registered with the desired priority, this method does nothing.
+     * <p>
+     * This executor runs high priority tasks every cycle, medium priority tasks slightly every other cycles, and low priority
+     * tasks every 4 cycles. All {@link Executable} tasks are called on the first cycle.
+     *
+     * @param task the executable task
+     * @param priority the priority of the executable; may not be null
+     * @return {@code true} if the executable task was registered for the first time at the given priority, or {@code false} if
+     *         {@code task} was null or was already registered with this executor at the given priority
+     */
+    public boolean register(Executable task, Priority priority);
 
     /**
      * Unregister an {@link Executable} task to no longer be called.
      *
-     * @param r the executable task
+     * @param task the executable task
      * @return true if the executable task was unregistered, or false if it was null or not registered with this executor
      */
-    public boolean unregister(Executable r);
+    public boolean unregister(Executable task);
 
     /**
      * Unregister all {@link Executable} tasks.

--- a/strongback/src/org/strongback/Logger.java
+++ b/strongback/src/org/strongback/Logger.java
@@ -27,7 +27,7 @@ import org.strongback.annotation.ThreadSafe;
 public interface Logger {
 
     public static enum Level {
-        ERROR, WARN, INFO, DEBUG, TRACE;
+        ERROR, WARN, INFO, DEBUG, TRACE, OFF;
     }
 
     /**

--- a/strongback/src/org/strongback/SystemLogger.java
+++ b/strongback/src/org/strongback/SystemLogger.java
@@ -26,6 +26,7 @@ import org.strongback.annotation.ThreadSafe;
 @ThreadSafe
 final class SystemLogger implements Logger {
 
+    private static final int OFF = 0;
     private static final int ERROR = 2 << 0;
     private static final int WARN = 2 << 1;
     private static final int INFO = 2 << 2;
@@ -93,7 +94,20 @@ final class SystemLogger implements Logger {
             case ERROR:
                 this.level = ERROR;
                 break;
+            case OFF:
+                this.level = OFF;
+                break;
         }
         return this;
+    }
+
+    @Override
+    public String toString() {
+        if ((this.level & TRACE) == TRACE) return "TRACE";
+        if ((this.level & DEBUG) == DEBUG) return "DEBUG";
+        if ((this.level & INFO) == INFO) return "INFO";
+        if ((this.level & WARN) == WARN) return "WARN";
+        if ((this.level & ERROR) == ERROR) return "ERROR";
+        return "OFF";
     }
 }

--- a/strongback/src/org/strongback/util/Metronome.java
+++ b/strongback/src/org/strongback/util/Metronome.java
@@ -31,7 +31,9 @@ import org.strongback.components.Clock;
  * millisecond on most platforms (especially modern Linux and OS X).
  *
  * @author Randall Hauch
+ * @deprecated
  */
+@Deprecated
 public interface Metronome {
 
     /**
@@ -146,7 +148,7 @@ public interface Metronome {
 
             @Override
             public boolean pause() {
-                while (next - timeSystem.currentTimeInNanos() > 0) {
+                while (next > timeSystem.currentTimeInNanos()) {
                 }
                 next = next + periodInNanos;
                 return true;


### PR DESCRIPTION
_**This change does not remove or change any public API methods, and therefore no robot code needs to be changed. However, a few of the Strongback configuration options available in previous versions are no longer supported, so the corresponding methods in `Strongback` and its configurator are now deprecated and may no longer have any affect.**_

This PR corrects a number of errors and simplifies the engine by rewrites how the `Strongback.java` class is implemented. All of the existing public methods are still available, though quite a few have been deprecated and now may no longer do anything. For example, the different timer modes and clocks only complicated how to configure Strongback, yet really didn’t offer any advantages and may have made the code worse by making the execution period less consistent. In short, robot code can continue to use these deprecated methods, but the methods may have no effect and could be removed from the robot’s codebase. Note that the deprecated methods will be removed in the next major release of Strongback for 2017.

This change also corrects and simplifies how the executor thread operates. Now, Strongback measures the time required to run all executables (e.g., the switch reactor, command scheduler, data recorder, event recorder, etc.), and uses this time to determine if the executor did not complete in the specified amount of time. This should improve the accuracy of the error messages about taking too long to execute each cycle. And Strongback only uses the “busy” timer mode and the system clock, which simplified the executor implementation.

Finally, Strongback now supports priorities for its executables:

* High priority executables will run every cycle of the executor;
* Medium priority executables will run every other cycle of the executor; and
* Low priority executables will run every 4th cycle of the executor.

Currently, the command scheduler (through with all commands are run) will operate at HIGH priority, while the data recorder (if used) and the switch reactor will operate at the MEDIUM priority. The event recorder still records the time at which events occurred, but events are written out at LOW priority.

Fixes #84.