### PR TITLE
Issue-90 Removed invalid characters from java docs

### DIFF
--- a/strongback/src/org/strongback/components/TalonSRX.java
+++ b/strongback/src/org/strongback/components/TalonSRX.java
@@ -145,9 +145,9 @@ public interface TalonSRX extends LimitedMotor {
      * specified range: forward throttle will be disabled if the "Sensor Position" is greater than the forward soft limit.
      * This takes effect only when the forward soft limit is {@link #enableForwardSoftLimit(boolean)}.
      * <p>
-     * Soft limits can be used to disable motor drive when the “Sensor Position” is outside of a specified range. Forward
-     * throttle will be disabled if the “Sensor Position” is greater than the Forward Soft Limit. Reverse throttle will be
-     * disabled if the “Sensor Position” is less than the Reverse Soft Limit. The respective Soft Limit Enable must be enabled
+     * Soft limits can be used to disable motor drive when the 'Sensor Position' is outside of a specified range. Forward
+     * throttle will be disabled if the 'Sensor Position' is greater than the Forward Soft Limit. Reverse throttle will be
+     * disabled if the 'Sensor Position' is less than the Reverse Soft Limit. The respective Soft Limit Enable must be enabled
      * for this feature to take effect.
      *
      * @param forwardLimitInDegrees the angle at which the forward throttle should be disabled, where the angle in terms of the
@@ -163,9 +163,9 @@ public interface TalonSRX extends LimitedMotor {
      * specified range: reverse throttle will be disabled if the "Sensor Position" is less than the reverse soft limit.
      * This takes effect only when the reverse soft limit is {@link #enableReverseSoftLimit(boolean)}.
      * <p>
-     * Soft limits can be used to disable motor drive when the “Sensor Position” is outside of a specified range. Forward
-     * throttle will be disabled if the “Sensor Position” is greater than the Forward Soft Limit. Reverse throttle will be
-     * disabled if the “Sensor Position” is less than the Reverse Soft Limit. The respective Soft Limit Enable must be enabled
+     * Soft limits can be used to disable motor drive when the 'Sensor Position' is outside of a specified range. Forward
+     * throttle will be disabled if the 'Sensor Position' is greater than the Forward Soft Limit. Reverse throttle will be
+     * disabled if the 'Sensor Position' is less than the Reverse Soft Limit. The respective Soft Limit Enable must be enabled
      * for this feature to take effect.
      *
      * @param reverseLimitInDegrees the angle at which the reverse throttle should be disabled, where the angle in terms of the

--- a/strongback/src/org/strongback/control/TalonController.java
+++ b/strongback/src/org/strongback/control/TalonController.java
@@ -47,7 +47,7 @@ import org.strongback.components.TalonSRX;
  * </pre>
  *
  * <p>
- * In order for limit switches and closed-loop features to function correctly, the sensor and motor have to be “in-phase”. This
+ * In order for limit switches and closed-loop features to function correctly, the sensor and motor have to be 'in-phase'. This
  * means that the sensor position must move in a <i>positive</i> direction as the motor controller drives <i>positive</i>
  * throttle. To test this, first drive the motor manually (using a human input device), and watch the sensor position either in
  * the roboRIO Web-based Configuration Self-Test, or by calling {@link #getSelectedSensor()} and printing it to console. If the


### PR DESCRIPTION
Removed characters from java docs that are considered invalid for the default Windows cp1252 encoding.

fixes #90