### PR TITLE
Issue-93 fixed to use the speedlimiter arg

### DIFF
--- a/strongback/src/org/strongback/hardware/Hardware.java
+++ b/strongback/src/org/strongback/hardware/Hardware.java
@@ -570,7 +570,7 @@ public class Hardware {
          * @return a motor on the specified channel
          */
         public static Motor victorSP(int channel, DoubleToDoubleFunction speedLimiter) {
-            return new HardwareMotor(new VictorSP(channel), SPEED_LIMITER);
+            return new HardwareMotor(new VictorSP(channel), speedLimiter);
         }
 
         /**


### PR DESCRIPTION
Fixed the version of the Hardware.Motors.victorSP(int channel, DoubleToDoubleFunction speedLimiter) method to use the passed in speedLimiter argument.

Fixes #93 