### PR TITLE
Fix Incorrect Indices for Microsoft Sidewinder

### DIFF
--- a/strongback/src/org/strongback/hardware/Hardware.java
+++ b/strongback/src/org/strongback/hardware/Hardware.java
@@ -104,7 +104,6 @@ public class Hardware {
 
     /**
      * Gets the {@link PneumaticsModule} of the robot with the supplied CAN ID. Multiple pneumatics modules can be used by
-     * specifying the correct CAN ID of each module.
      *
      * @param canID the CAN ID of the module
      * @return the {@link PneumaticsModule} of the robot; never null
@@ -864,8 +863,8 @@ public class Hardware {
                                       joystick::getTwist, // yaw
                                       joystick::getX, // roll
                                       joystick::getThrottle, // throttle
-                                      () -> joystick.getRawButton(0), // trigger
-                                      () -> joystick.getRawButton(1)); // thumb
+                                      () -> joystick.getRawButton(1), // trigger
+                                      () -> joystick.getRawButton(2)); // thumb
         }
 
         /**


### PR DESCRIPTION
WPILib requires `Joystick::getRawButton` to start at index 1, not index 0. This may be necessary for other joysticks, but my team does not have any others to test.