### PR TITLE
Fixed SoftwarePIDController checkTolerance and initTable

### DIFF
--- a/strongback-tests/src/org/strongback/control/SoftwarePIDControllerTest.java
+++ b/strongback-tests/src/org/strongback/control/SoftwarePIDControllerTest.java
@@ -256,6 +256,34 @@ public class SoftwarePIDControllerTest {
         assertThat(model.getActualValue() - 0.5 < 0.02).isTrue();
     }
 
+    @Test
+    public void shouldCorrectlyOutputWithinTolerance() {
+        final double target = 0.5;
+        final double tolerance = 0.02;
+
+        // Not within tolerance should return false
+        model = simple();
+        model.setValue(0);
+        controller = new SoftwarePIDController(model::sourceType, model::getActualValue, model::setValue)
+                .withGains(0.9, 0.0, 0.0)
+                .withInputRange(-1.0, 1.0)
+                .withOutputRange(-1.0, 1.0)
+                .withTolerance(tolerance)
+                .withTarget(target);
+        assertThat(controller.isWithinTolerance()).isFalse();
+
+        // Within tolerance should return true
+        model = simple();
+        model.setValue(target - tolerance + 0.001);
+        controller = new SoftwarePIDController(model::sourceType, model::getActualValue, model::setValue)
+                .withGains(0.9, 0.0, 0.0)
+                .withInputRange(-1.0, 1.0)
+                .withOutputRange(-1.0, 1.0)
+                .withTolerance(tolerance)
+                .withTarget(target);
+        assertThat(controller.isWithinTolerance()).isTrue();
+    }
+
     protected int runController(int maxNumSteps) {
         int counter = 0;
         while (!controller.computeOutput() && counter < maxNumSteps) {

--- a/strongback/src/org/strongback/control/Controller.java
+++ b/strongback/src/org/strongback/control/Controller.java
@@ -98,7 +98,7 @@ public interface Controller extends Requirable {
      * @return <code>true</code> if the proposed value is within the tolerance of the target, or <code>false</code> otherwise
      */
     public default boolean checkTolerance(double value) {
-        return Math.abs(value) <= (getTarget() - getTolerance());
+        return Math.abs(getTarget() - value) < getTolerance();
     }
 
     /**

--- a/strongback/src/org/strongback/control/SoftwarePIDController.java
+++ b/strongback/src/org/strongback/control/SoftwarePIDController.java
@@ -656,7 +656,7 @@ public class SoftwarePIDController implements LiveWindowSendable, PIDController 
         }
 
         public boolean isWithinTolerance(double value) {
-            return Math.abs(value) <= (setpoint - tolerance);
+            return calculateError(value) < tolerance;
         }
 
         public double calculateError(double input) {
@@ -721,7 +721,7 @@ public class SoftwarePIDController implements LiveWindowSendable, PIDController 
         if (this.table != null) {
             this.table.removeTableListener(listener);
         }
-        this.table = table;
+        this.table = subtable;
         if (table != null) {
             Gains gains = this.gains;
             Target target = this.target;


### PR DESCRIPTION
Hey again! My co-lead and I came across what we believe are two separate bugs in the SoftwarePIDController. Seeing as they're each relatively small to review, I hope you don't mind that I've combined them both into one PR.

1. **The checkTolerance method is inaccurate**. It checks to see if the input is less than the setpoint minus the tolerance, which means basically *any* input less than the setpoint is considered in tolerance. This had the ugly effect of causing our controller commands to prematurely finish. I've thrown in a regression test that verifies the method now works as intended.

2. **The gains don't appear on the SmartDashboard**. It looks like `this.table = table` is the culprit :) I compared this line to the corresponding line in the WPILib PIDController and I believe it should have been set to `subtable`.