### PR TITLE
Issue 111 - Support CommandGroups in CommandTester

### DIFF
--- a/strongback-testing/src/org/strongback/command/CommandTester.java
+++ b/strongback-testing/src/org/strongback/command/CommandTester.java
@@ -24,7 +24,7 @@ public class CommandTester {
     private final CommandRunner runner;
 
     public CommandTester(Command command) {
-        runner = new CommandRunner(command);
+        runner = CommandRunner.create(command);
     }
 
     /**

--- a/strongback-tests/src/org/strongback/command/CommandTesterTest.java
+++ b/strongback-tests/src/org/strongback/command/CommandTesterTest.java
@@ -1,0 +1,27 @@
+package org.strongback.command;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Rothanak So
+ */
+public class CommandTesterTest {
+
+    @Test
+    public void shouldSupportCommandGroups() {
+        // Regression test for issue #111: https://github.com/strongback/strongback-java/issues/111
+        Command command = Command.pause(100, TimeUnit.MILLISECONDS);
+        WatchedCommand watched = WatchedCommand.watch(command); // CommandGroups don't call end(), so watch Command
+        CommandTester tester = new CommandTester(CommandGroup.runSequentially(watched));
+
+        tester.step(1);
+        assertThat(watched.isEnded()).isFalse();
+
+        tester.step(101);
+        assertThat(watched.isEnded()).isTrue();
+    }
+}

--- a/strongback/src/org/strongback/command/Scheduler.java
+++ b/strongback/src/org/strongback/command/Scheduler.java
@@ -65,35 +65,9 @@ public class Scheduler implements Executable {
      */
     public void submit(Command command) {
         if (command != null) {
-            CommandRunner runner = buildRunner(command, null);
+            CommandRunner runner = CommandRunner.create(context, command);
             commands.add(runner);
         }
-    }
-
-    private CommandRunner buildRunner(Command command, CommandRunner last) {
-        if (command instanceof CommandGroup) {
-            CommandGroup cg = (CommandGroup) command;
-            Command[] commands = cg.getCommands();
-            switch (cg.getType()) {
-                case SEQUENTIAL:
-                    for (int i = commands.length - 1; i >= 0; i--) {
-                        last = buildRunner(commands[i], last);
-                    }
-                    return last;
-                case PARRALLEL:
-                    CommandRunner[] crs = new CommandRunner[commands.length];
-                    for (int i = 0; i < crs.length; i++) {
-                        crs[i] = buildRunner(commands[i], null);
-                    }
-                    return new CommandRunner(context, last, crs);
-                case FORK:
-                    assert commands.length == 1;
-                    return new CommandRunner(context, last, new CommandRunner(context, buildRunner(commands[0], null)));
-            }
-            // This line should never happen, the switch will throw an exception first
-            throw new IllegalStateException("Unexpected command type: " + cg.getType());
-        }
-        return new CommandRunner(context, last, command);
     }
 
     /**


### PR DESCRIPTION
This PR addresses #111 and moves the `buildRunner` method from Scheduler into CommandRunner so CommandTester can also correctly execute CommandGroups.

To keep the code clean, I've adjusted the CommandRunner to expose two static builders:

* **`CommandRunner#create(Context, Command)`**
* **`CommandRunner#create(Command)`**

These builders call into `buildRunner`. After some refactoring, I was left with only two CommandRunner constructors. Both are only used by the `buildRunner` so I made them private. Regression/integration tests included. Let me know what you think and if there's anything you'd like me to change. Thanks!